### PR TITLE
Reorder exports field as recommended by TypeScript

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,9 +8,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     }
   },
   "keywords": [


### PR DESCRIPTION
Thanks to [Publint](https://publint.dev/@lunariajs/core@0.0.1) I found out the `types` field should come first as it is recommended by TypeScript. 