### PR TITLE
Fix `@lunariajs/core` .cjs types & published files

### DIFF
--- a/.changeset/great-hounds-applaud.md
+++ b/.changeset/great-hounds-applaud.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Fix .cjs types & published files in `package.json`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,11 +8,20 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
     }
   },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
   "keywords": [
     "i18n",
     "translation",


### PR DESCRIPTION
This PR fixes the exports type fields [as recommended by TypeScript](https://publint.dev/rules#export_types_invalid_format) and includes a `files` field of the files to be published.