### PR TITLE
UI Dictionaries improvements & dashboard fixes

### DIFF
--- a/.changeset/quick-books-exercise.md
+++ b/.changeset/quick-books-exercise.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+UI Dictionaries improvements & dashboard rendering fix

--- a/examples/vitepress/scripts/translation-status.ts
+++ b/examples/vitepress/scripts/translation-status.ts
@@ -28,7 +28,7 @@ const tracker = await createTracker({
 			ignore: ['pt/*.md', 'es/*.md'],
 		},
 		dictionaries: {
-			location: 'ui/en/*.{js,cjs,mjs,ts,yml}',
+			location: 'ui/en/*.{js,cjs,mjs,ts,yml,json}',
 		},
 	},
 	locales: [
@@ -39,7 +39,7 @@ const tracker = await createTracker({
 				location: 'pt/**/*.md',
 			},
 			dictionaries: {
-				location: 'ui/pt/*.{js,cjs,mjs,ts,yml}',
+				location: 'ui/pt/*.{js,cjs,mjs,ts,yml,json}',
 			},
 		},
 		{
@@ -49,7 +49,7 @@ const tracker = await createTracker({
 				location: 'es/**/*.md',
 			},
 			dictionaries: {
-				location: 'ui/es/*.{js,cjs,mjs,ts,yml}',
+				location: 'ui/es/*.{js,cjs,mjs,ts,yml,json}',
 			},
 		},
 	],

--- a/examples/vitepress/ui/pt/nav.json
+++ b/examples/vitepress/ui/pt/nav.json
@@ -1,4 +1,3 @@
 {
-  "greeting": "hello",
-  "today": "today"
+  "greeting": "hello"
 }

--- a/examples/vitepress/ui/pt/ui.cjs
+++ b/examples/vitepress/ui/pt/ui.cjs
@@ -1,4 +1,3 @@
 module.exports = {
 	brand: 'Automobiles',
-	type: 'Comfort',
 };

--- a/examples/vitepress/ui/pt/ui.js
+++ b/examples/vitepress/ui/pt/ui.js
@@ -1,4 +1,3 @@
 export default {
 	brand: 'Automobiles',
-	type: 'Comfort',
 };

--- a/examples/vitepress/ui/pt/ui.mjs
+++ b/examples/vitepress/ui/pt/ui.mjs
@@ -1,4 +1,3 @@
 export default {
 	brand: 'Automobiles',
-	type: 'Comfort',
 };

--- a/examples/vitepress/ui/pt/ui.mts
+++ b/examples/vitepress/ui/pt/ui.mts
@@ -1,4 +1,3 @@
 export default {
 	brand: 'Automobiles',
-	type: 'Comfort',
 };

--- a/examples/vitepress/ui/pt/ui.ts
+++ b/examples/vitepress/ui/pt/ui.ts
@@ -1,4 +1,3 @@
 export default {
 	brand: 'Automobiles',
-	type: 'Comfort',
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "fast-glob": "^3.3.1",
+    "jiti": "^1.21.0",
     "lit-html": "^3.0.0",
     "micromatch": "^4.0.5",
     "rehype": "^13.0.1",

--- a/packages/core/src/dashboard/components.ts
+++ b/packages/core/src/dashboard/components.ts
@@ -173,7 +173,7 @@ export const StatusByContent = (
 					)}
 				</tr>
 			</thead>
-			${TableBody(translationStatus, dashboard)}
+			${TableBody(translationStatus, locales, dashboard)}
 		</table>
 		<sup class="capitalize"
 			>${getTextFromFormat(dashboard.ui['statusByContent.tableSummaryFormat'], {
@@ -188,19 +188,23 @@ export const StatusByContent = (
 	`;
 };
 
-export const TableBody = (translationStatus: FileTranslationStatus[], dashboard: Dashboard) => {
+export const TableBody = (
+	translationStatus: FileTranslationStatus[],
+	locales: Locale[],
+	dashboard: Dashboard
+) => {
 	return html`
 		<tbody>
 			${translationStatus.map(
-				(page) => html`
+				(page) =>
+					html`
 				<tr>
 					<td>${GitHostingLink(page.gitHostingUrl, page.sharedPath)}</td>
-						${Object.keys(page.translations).map((lang) =>
-							TableContentStatus(page.translations, lang, dashboard)
-						)}
+						${locales.map(({ lang }) => {
+							return TableContentStatus(page.translations, lang, dashboard);
+						})}
 					</td>
-				</tr>
-			`
+				</tr>`
 			)}
 		</tbody>
 	`;
@@ -234,21 +238,23 @@ export const ContentDetailsLinks = (
 	page: FileTranslationStatus,
 	lang: string,
 	dashboard: Dashboard
-) => html`
-	${GitHostingLink(page.gitHostingUrl, page.sharedPath)}
-	${page.translations[lang]
-		? html`(${GitHostingLink(
-				page.translations[lang]?.gitHostingUrl!,
-				!page.translations[lang]?.completeness.complete
-					? dashboard.ui['statusByLocale.incompleteTranslationLink']
-					: dashboard.ui['statusByLocale.outdatedTranslationLink']
-		  )},
-		  ${GitHostingLink(
-				page.translations[lang]?.sourceHistoryUrl!,
-				dashboard.ui['statusByLocale.sourceChangeHistoryLink']
-		  )})`
-		: ''}
-`;
+) => {
+	return html`
+		${GitHostingLink(page.gitHostingUrl, page.sharedPath)}
+		${page.translations[lang]
+			? html`(${GitHostingLink(
+					page.translations[lang]?.gitHostingUrl!,
+					!page.translations[lang]?.completeness.complete
+						? dashboard.ui['statusByLocale.incompleteTranslationLink']
+						: dashboard.ui['statusByLocale.outdatedTranslationLink']
+			  )},
+			  ${GitHostingLink(
+					page.translations[lang]?.sourceHistoryUrl!,
+					dashboard.ui['statusByLocale.sourceChangeHistoryLink']
+			  )})`
+			: ''}
+	`;
+};
 
 export const GitHostingLink = (href: string, text: string) => {
 	return html`<a href="${href}">${text}</a>`;

--- a/packages/core/src/tracker.ts
+++ b/packages/core/src/tracker.ts
@@ -209,7 +209,7 @@ export async function getContentIndex(opts: LunariaConfig, isShallowRepo: boolea
 		const dictionaryContentIndex = [];
 
 		if (dictionaries) {
-			const { location, ignore, optionalKeys, module } = dictionaries;
+			const { location, ignore, optionalKeys } = dictionaries;
 
 			const localeDictionariesPaths = await glob(location, {
 				cwd: process.cwd(),
@@ -235,7 +235,6 @@ export async function getContentIndex(opts: LunariaConfig, isShallowRepo: boolea
 							additionalData: {
 								type: 'dictionary',
 								optionalKeys: optionalKeys ?? defaultLocale?.dictionaries?.optionalKeys,
-								module,
 							},
 						} as IndexData;
 					})

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,7 +33,6 @@ export interface FileData {
 interface DictionaryContentData {
 	type: 'dictionary';
 	optionalKeys: string[];
-	module: string;
 }
 
 interface GenericContentData {

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -24,13 +24,6 @@ const DictionariesSchema = z.object({
 		.describe('Array of glob patterns to be ignored from matching.'),
 	/** Object whose keys equals to true will have its translation considered optional. The value configured in the defaultLocale will be considered for all locales, while individual locales can override it with locale-specific information. */
 	optionalKeys: z.array(z.string()).optional(),
-	/** The name of the export that will be used to import your dictionary. As the initial value, the default export is used. */
-	module: z
-		.string()
-		.default('default')
-		.describe(
-			'The name of the export that will be used to import your dictionary. As the initial value, the default export is used.'
-		),
 });
 
 const ContentSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       fast-glob:
         specifier: ^3.3.1
         version: 3.3.1
+      jiti:
+        specifier: ^1.21.0
+        version: 1.21.0
       lit-html:
         specifier: ^3.0.0
         version: 3.0.0
@@ -3698,10 +3701,9 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  /jiti@1.20.0:
-    resolution: {integrity: sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==}
+  /jiti@1.21.0:
+    resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
-    dev: true
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4568,7 +4570,7 @@ packages:
       esbuild: 0.18.20
       fs-extra: 11.1.1
       globby: 13.2.2
-      jiti: 1.20.0
+      jiti: 1.21.0
       mlly: 1.4.2
       mri: 1.2.0
       pathe: 1.1.1
@@ -6023,7 +6025,7 @@ packages:
       esbuild: 0.19.4
       globby: 13.2.2
       hookable: 5.5.3
-      jiti: 1.20.0
+      jiti: 1.21.0
       magic-string: 0.30.4
       mkdist: 1.3.0(typescript@5.2.2)
       mlly: 1.4.2
@@ -6200,7 +6202,7 @@ packages:
       '@babel/standalone': 7.23.2
       '@babel/types': 7.23.0
       defu: 6.1.3
-      jiti: 1.20.0
+      jiti: 1.21.0
       mri: 1.2.0
       scule: 1.0.0
     transitivePeerDependencies:


### PR DESCRIPTION
This PR makes several improvements to UI Dictionaries and as usual, dashboard fixes:
- A new way to import UI Dictionaries, `unjs/jiti` handles the transpilation of JavaScript and TypeScript at runtime and avoids the need to use `ts-node` or other projects to run it, while JSON dictionaries are read from the file system and parsed to avoid usage of experimental Node features.
- UI Dictionaries now are 100% recursive Records, being parsed by `zod`. If a invalid UI Dictionary format is found, the code throws an error and exits.
- This new approach removes the support for different specified modules, therefore its option is now deprecated and removed from the config file.
- Solved a bug where the `<StatusByContent />` table component would render the status in the wrong order.  