### PR TITLE
Improve `optionalKeys` API

### DIFF
--- a/examples/vitepress/lunaria.config.ts
+++ b/examples/vitepress/lunaria.config.ts
@@ -29,6 +29,15 @@ export default defineConfig({
 		},
 		dictionaries: {
 			location: 'ui/en/*.{js,cjs,mjs,ts,yml,json}',
+			optionalKeys: {
+				'ui/nav.json': ['today'],
+				'ui/ui.cjs': ['type'],
+				'ui/ui.js': ['type'],
+				'ui/ui.mjs': ['type'],
+				'ui/ui.mts': ['type'],
+				'ui/ui.ts': ['type'],
+				'ui/ui.yml': ['here'],
+			},
 		},
 	},
 	locales: [

--- a/packages/core/src/schemas/locale.ts
+++ b/packages/core/src/schemas/locale.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
 
+const OptionalKeysSchema = z
+	.record(z.string(), z.array(z.string()).nonempty())
+	.default({})
+	.describe(
+		"Record of dictionary shared paths whose values are an array of dictionary keys to be marked as optional. While defining on the default locale's object applies it to all languages, you can pass additional keys as part of the specific locale's `optionalKeys` field."
+	);
+
 const DictionariesSchema = z
 	.object({
 		/** A glob pattern of where your UI dictionaries are and its file type(s), e.g. `"src/i18n/en/**.ts"`. */
@@ -13,8 +20,10 @@ const DictionariesSchema = z
 			.array(z.string())
 			.default([])
 			.describe('Array of glob patterns to be ignored from matching.'),
-		/** Object whose keys equals to true will have its translation considered optional. The value configured in the defaultLocale will be considered for all locales, while individual locales can override it with locale-specific information. */
-		optionalKeys: z.array(z.string()).optional(),
+		/** Record of dictionary shared paths whose values are an array of dictionary keys to be marked as optional.
+		 * While defining on the default locale's object applies it to all languages, you can pass additional keys
+		 * as part of the specific locale's `optionalKeys` field. */
+		optionalKeys: OptionalKeysSchema,
 	})
 	.optional();
 
@@ -52,3 +61,4 @@ export const LocaleSchema = z.object({
 });
 
 export type Locale = z.output<typeof LocaleSchema>;
+export type OptionalKeys = z.infer<typeof OptionalKeysSchema>;

--- a/packages/core/src/tracker.ts
+++ b/packages/core/src/tracker.ts
@@ -16,6 +16,7 @@ import type {
 	FileTranslationStatus,
 	IndexData,
 	LunariaConfig,
+	OptionalKeys,
 	RegExpGroups,
 	SharedPathResolver,
 } from './types.js';
@@ -67,6 +68,7 @@ export async function getTranslationStatus(
 					fileStatus.translations[lang] = {
 						file: translationFile,
 						completeness: await getDictionaryTranslationStatus(
+							defaultLocale.dictionaries?.optionalKeys,
 							translationFile,
 							sourceFile.filePath,
 							sharedPath
@@ -190,7 +192,7 @@ export async function getContentIndex(opts: LunariaConfig, isShallowRepo: boolea
 							),
 							additionalData: {
 								type: 'dictionary',
-								optionalKeys: optionalKeys ?? defaultLocale?.dictionaries?.optionalKeys,
+								optionalKeys: optionalKeys,
 							},
 						} as IndexData;
 					})
@@ -335,6 +337,7 @@ function isTranslatable(filePath: string, translatableProperty: string | undefin
 }
 
 async function getDictionaryTranslationStatus(
+	defaultOptionalKeys: OptionalKeys | undefined,
 	dictionary: AugmentedFileData | undefined,
 	sourceFilePath: string,
 	sharedPath: string
@@ -352,7 +355,10 @@ async function getDictionaryTranslationStatus(
 	}
 
 	const missingKeys = Object.keys(sourceData).flatMap((key) => {
-		const isOptionalKey = optionalKeys?.find((optionalKey) => optionalKey === key);
+		const isOptionalKey =
+			(defaultOptionalKeys?.[sharedPath]?.includes(key) ??
+				optionalKeys[sharedPath]?.includes(key)) === true;
+
 		if (!translationData.hasOwnProperty(key) && !isOptionalKey) return key;
 		return [];
 	});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,7 +3,7 @@ import type { LunariaConfig } from './schemas/config.js';
 
 type DictionaryContentData = {
 	type: 'dictionary';
-	optionalKeys: string[];
+	optionalKeys: Record<string, string[]>;
 };
 
 type GenericContentData = {


### PR DESCRIPTION
This PR improves the `optionalKeys` API, allowing you to define which dictionaries (through its `sharedPath`) should receive the specified array of optional keys.