### PR TITLE
Add `localePathConstructor` & improve git hosting links

### DIFF
--- a/.changeset/tender-deers-taste.md
+++ b/.changeset/tender-deers-taste.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Add `localePathConstructor` & improve git hosting links

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,7 @@
     "rehype": "^13.0.1",
     "rehype-format": "^5.0.0",
     "simple-git": "^3.20.0",
+    "ufo": "^1.3.1",
     "ultramatter": "^0.0.4",
     "zod": "^3.22.3"
   }

--- a/packages/core/src/dashboard/components.ts
+++ b/packages/core/src/dashboard/components.ts
@@ -107,12 +107,19 @@ export const LocaleDetails = (
 				${ProgressBar(translationStatus.length, outdatedPages.length, missingPages.length)}
 			</summary>
 			${outdatedPages.length > 0 ? OutdatedPages(outdatedPages, lang, dashboard) : ''}
-			<!-- TODO: see if this is rendering correctly -->
 			${missingPages.length > 0
 				? html`<h3 class="capitalize">${dashboard.ui['status.missing']}</h3>
 						<ul>
 							${missingPages.map(
-								(page) => html` <li>${GitHostingLink(page.gitHostingUrl, page.sharedPath)}</li> `
+								(page) => html`
+									<li>
+										${GitHostingLink(page.gitHostingUrl, page.sharedPath)}
+										${CreatePageLink(
+											page.translations[lang]?.gitHostingUrl!,
+											dashboard.ui['statusByLocale.createFileLink']
+										)}
+									</li>
+								`
 							)}
 						</ul>`
 				: ''}
@@ -258,6 +265,10 @@ export const ContentDetailsLinks = (
 
 export const GitHostingLink = (href: string, text: string) => {
 	return html`<a href="${href}">${text}</a>`;
+};
+
+export const CreatePageLink = (href: string, text: string) => {
+	return html`<a class="create-button" href="${href}">${text}</a>`;
 };
 
 export const ProgressBar = (

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -1,9 +1,11 @@
+import { normalizeURL } from 'ufo';
 import { z } from 'zod';
 import { DashboardSchema } from '../schemas/dashboard.js';
 import { LocaleSchema } from '../schemas/locale.js';
-import { SharedPathResolverSchema } from '../schemas/misc.js';
+import { LocalePathConstructorSchema, SharedPathResolverSchema } from '../schemas/misc.js';
 
 export const LunariaConfigSchema = z.object({
+	/** Options about your generated dashboard. */
 	dashboard: DashboardSchema,
 	/** The default locale of your content that is going to be translated. */
 	defaultLocale: LocaleSchema,
@@ -22,22 +24,23 @@ export const LunariaConfigSchema = z.object({
 		.string()
 		.optional()
 		.describe('Name of the frontmatter property used to mark a page as ready for translation.'),
-	/** Custom fuction to handle the shared path resolver, used to "link" pages between two locales. */
-	customSharedPathResolver: SharedPathResolverSchema,
+	/** Fuction to extract a shared path from a locale's path, used to 'link' the content between two locales. */
+	sharedPathResolver: SharedPathResolverSchema,
+	/** Fuction to construct the locale-specific path from the source path of the same content. */
+	localePathConstructor: LocalePathConstructorSchema,
 	/** The URL of your current repository, used to generate history links, e.g. `"https://github.com/Yan-Thomas/lunaria"`. */
 	repository: z
 		.string()
 		.url()
 		.refine(
-			(link) => link.startsWith('https://github.com/') || link.startsWith('https://gitlab.com/'),
+			(url) => url.startsWith('https://github.com/') || url.startsWith('https://gitlab.com/'),
 			{
 				message: 'URL needs to be a valid `"https://github.com/"` or `"https://gitlab.com/"` link.',
 			}
 		)
-		// Removes any trailing slashes
-		.transform((link) => link.replace(/\/+$/, ''))
+		.transform((url) => normalizeURL(url))
 		.describe(
-			'The URL of your current repository, used to generate history links, e.g. `"github.com/Yan-Thomas/lunaria"`.'
+			'The URL of your current repository, used to generate history links, e.g. `"https://github.com/Yan-Thomas/lunaria/"`.'
 		),
 	/** The root directory of the project being tracked, must be set when using a monorepo.
 	 *

--- a/packages/core/src/schemas/dashboard.ts
+++ b/packages/core/src/schemas/dashboard.ts
@@ -84,6 +84,11 @@ const DashboardUiSchema = z
 			.string()
 			.default('incomplete translation')
 			.describe("The text for the locale's details incomplete translation link."),
+		/** The text for the locale's details create file link. */
+		'statusByLocale.createFileLink': z
+			.string()
+			.default('Create page')
+			.describe("The text for the locale's details create file link."),
 		/** The text for the locale's details source change history link. */
 		'statusByLocale.sourceChangeHistoryLink': z
 			.string()

--- a/packages/core/src/schemas/misc.ts
+++ b/packages/core/src/schemas/misc.ts
@@ -6,13 +6,53 @@ export const SharedPathResolverSchema = z
 	.args(
 		z.object({
 			lang: z.string(),
-			filePath: z.string(),
+			localePath: z.string(),
 		})
 	)
 	.returns(z.string())
 	.optional()
+	.default(() => ({ lang, localePath }: { lang: string; localePath: string }) => {
+		const pathParts = localePath.split('/');
+		const localePartIndex = pathParts.findIndex((part) => part === lang);
+		if (localePartIndex > -1) pathParts.splice(localePartIndex, 1);
+
+		return pathParts.join('/');
+	})
 	.describe(
-		'Custom fuction to handle the shared path resolver, used to "link" pages between two locales.'
+		"Fuction to extract a shared path from a locale's path, used to 'link' the content between two locales."
+	);
+
+export const LocalePathConstructorSchema = z
+	.function()
+	.args(
+		z.object({
+			sourceLang: z.string(),
+			localeLang: z.string(),
+			sourcePath: z.string(),
+		})
+	)
+	.returns(z.string())
+	.optional()
+	.default(
+		() =>
+			({
+				sourceLang,
+				localeLang,
+				sourcePath,
+			}: {
+				sourceLang: string;
+				localeLang: string;
+				sourcePath: string;
+			}) => {
+				const pathParts = sourcePath.split('/');
+				const localePartIndex = pathParts.findIndex((part) => part === sourceLang);
+				if (localePartIndex > -1) pathParts.splice(localePartIndex, 1, localeLang);
+
+				return pathParts.join('/');
+			}
+	)
+	.describe(
+		'Fuction to construct the locale-specific path from the source path of the same content.'
 	);
 
 export const DictionaryContentSchema: z.ZodType<DictionaryObject> = z.record(
@@ -21,3 +61,4 @@ export const DictionaryContentSchema: z.ZodType<DictionaryObject> = z.record(
 );
 
 export type SharedPathResolver = z.infer<typeof SharedPathResolverSchema>;
+export type LocalePathConstructor = z.infer<typeof LocalePathConstructorSchema>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,9 +1,10 @@
 import type { TemplateResult } from 'lit-html';
 import type { LunariaConfig } from './schemas/config.js';
+import type { OptionalKeys } from './schemas/locale.js';
 
 type DictionaryContentData = {
 	type: 'dictionary';
-	optionalKeys: Record<string, string[]>;
+	optionalKeys: OptionalKeys;
 };
 
 type GenericContentData = {
@@ -37,12 +38,12 @@ export type FileData = {
 	lastMajorCommitMessage: string;
 };
 
-export type GitHostingUrl = {
+export type GitHostingURL = {
 	type?: string;
 	refName?: string;
 	query?: string;
 	repository: string;
-	filePath: string;
+	filePath?: string;
 	rootDir: string;
 };
 

--- a/packages/core/src/utils/git.ts
+++ b/packages/core/src/utils/git.ts
@@ -1,8 +1,8 @@
 import { existsSync, rmSync } from 'node:fs';
 import os from 'node:os';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import { simpleGit } from 'simple-git';
-import type { GitHostingUrl, LunariaConfig } from '../types.js';
+import type { LunariaConfig } from '../types.js';
 
 const git = simpleGit({
 	maxConcurrentProcesses: Math.max(2, Math.min(32, os.cpus().length)),
@@ -42,16 +42,4 @@ export async function getPageHistory(filePath: string) {
 		latest: log.latest,
 		all: log.all,
 	};
-}
-
-/* TODO: Looks like we aren't getting a URL with proper '//' in the https:// part, although the link works anyway. Gotta investigate. */
-export function getGitHostingUrl({
-	type = 'blob',
-	refName = 'main',
-	query = '',
-	repository,
-	rootDir,
-	filePath,
-}: GitHostingUrl) {
-	return (join(repository, type, refName, rootDir, filePath) + query).replaceAll('\\', '/');
 }

--- a/packages/core/src/utils/misc.ts
+++ b/packages/core/src/utils/misc.ts
@@ -1,8 +1,10 @@
 import jiti from 'jiti';
 import { readFileSync } from 'node:fs';
 import { extname } from 'node:path';
+import { joinURL } from 'ufo';
 import { parse } from 'ultramatter';
 import { frontmatterFileExtensions } from '../constants.js';
+import type { GitHostingURL } from '../types.js';
 
 export function renderToString(data: any) {
 	const { strings, values } = data;
@@ -63,3 +65,14 @@ export const loadFile = jiti(process.cwd(), {
 	interopDefault: true,
 	esmResolve: true,
 });
+
+export function getGitHostingURL({
+	type = 'blob',
+	refName = 'main',
+	query = '',
+	repository,
+	rootDir,
+	filePath = '',
+}: GitHostingURL) {
+	return joinURL(repository, type, refName, rootDir, filePath, query);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       simple-git:
         specifier: ^3.20.0
         version: 3.20.0
+      ufo:
+        specifier: ^1.3.1
+        version: 1.3.1
       ultramatter:
         specifier: ^0.0.4
         version: 0.0.4


### PR DESCRIPTION
This PR is focused on improving the links generated from the dashboard. Now, we have a new configuration option called `localePathConstructor`, meant to be the inverse of `sharedPathResolver`, that is, it creates a locale-specific path from a source file path, meaning when we don't have that page yet but we need a hypothetical one for a "Create page" link.

The dependency `ufo` was also introduced to help take care of joining and normalizing the URLs across the dashboard.;