### PR TITLE
Add `create-lunaria` package and improve `@lunariajs/core` configuration error

### DIFF
--- a/.changeset/perfect-timers-float.md
+++ b/.changeset/perfect-timers-float.md
@@ -1,0 +1,6 @@
+---
+"@lunariajs/core": patch
+"create-lunaria": patch
+---
+
+Add `create-lunaria` package and improve `@lunariajs/core` configuration error

--- a/build.preset.ts
+++ b/build.preset.ts
@@ -1,0 +1,13 @@
+import { definePreset } from 'unbuild';
+
+export default definePreset({
+	clean: true,
+	declaration: true,
+	sourcemap: true,
+	rollup: {
+		esbuild: {
+			target: 'es2022',
+			minify: true,
+		},
+	},
+});

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "version": "1.0.0",
   "scripts": {
     "docs": "pnpm --filter lunaria-docs dev",
-    "build": "pnpm run build:core",
+    "build": "pnpm run build:core && pnpm run build:create-lunaria",
     "build:core": "pnpm --filter @lunariajs/core build",
-    "lint": "pnpm run lint:core",
+    "build:create-lunaria": "pnpm --filter create-lunaria build",
+    "lint": "pnpm run lint:core && pnpm run lint:create-lunaria",
     "lint:core": "pnpm --filter @lunariajs/core lint",
+    "lint:create-lunaria": "pnpm --filter create-lunaria lint",
     "format": "prettier -w --cache --plugin prettier-plugin-astro .",
     "version": "pnpm changeset version && pnpm i --no-frozen-lockfile"
   },
@@ -16,7 +18,8 @@
     "@changesets/cli": "^2.26.2",
     "prettier": "3.0.3",
     "prettier-plugin-astro": "0.12.0",
-    "prettier-plugin-organize-imports": "^3.2.3"
+    "prettier-plugin-organize-imports": "^3.2.3",
+    "unbuild": "^2.0.0"
   },
   "packageManager": "pnpm@8.7.6"
 }

--- a/packages/core/build.config.ts
+++ b/packages/core/build.config.ts
@@ -1,14 +1,6 @@
 import { defineBuildConfig } from 'unbuild';
 
 export default defineBuildConfig({
+	preset: '../../build.preset.ts',
 	entries: ['src/index', 'src/dashboard/components', 'src/cli'],
-	clean: true,
-	declaration: true,
-	sourcemap: true,
-	rollup: {
-		esbuild: {
-			target: 'es2022',
-			minify: true,
-		},
-	},
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,8 +45,7 @@
   "devDependencies": {
     "@types/micromatch": "^4.0.3",
     "@types/node": "^20.8.9",
-    "typescript": "^5.2.2",
-    "unbuild": "^2.0.0"
+    "typescript": "^5.2.2"
   },
   "dependencies": {
     "c12": "^1.5.1",

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -10,7 +10,7 @@ const { config } = await loadConfig({
 	name: 'lunaria',
 });
 
-if (!config || !Object.keys(config).length) {
+if (config === null) {
 	console.error(new Error('Could not find a `lunaria.config.*` file, does it exist?'));
 	process.exit(1);
 }

--- a/packages/create-lunaria/README.md
+++ b/packages/create-lunaria/README.md
@@ -1,0 +1,18 @@
+# `create-lunaria`
+
+The `create-lunaria` is a setup wizard for setting up Lunaria into your project.
+
+## Usage
+
+Start by installing and executing the setup wizard in your terminal:
+
+```bash
+# npm
+npm create lunaria@latest
+
+# pnpm
+pnpm create lunaria@latest
+
+# yarn
+yarn create lunaria@latest
+```

--- a/packages/create-lunaria/build.config.ts
+++ b/packages/create-lunaria/build.config.ts
@@ -1,0 +1,5 @@
+import { defineBuildConfig } from 'unbuild';
+
+export default defineBuildConfig({
+	entries: ['src/create-lunaria'],
+});

--- a/packages/create-lunaria/package.json
+++ b/packages/create-lunaria/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "create-lunaria",
+  "type": "module",
+  "version": "0.0.0",
+  "bin": "./dist/create-lunaria.mjs",
+  "exports": {
+    ".": "./dist/create-lunaria.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "dist"
+  ],
+  "author": "Yan Thomas",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Yan-Thomas/lunaria",
+    "directory": "packages/create-lunaria"
+  },
+  "bugs": "https://github.com/Yan-Thomas/lunaria/issues",
+  "scripts": {
+    "dev": "node ./dist/create-lunaria.mjs",
+    "build": "unbuild",
+    "lint": "tsc",
+    "lunaria": "lunaria"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.9",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "@clack/prompts": "^0.7.0",
+    "nypm": "^0.3.3",
+    "picocolors": "^1.0.0"
+  }
+}

--- a/packages/create-lunaria/src/create-lunaria.ts
+++ b/packages/create-lunaria/src/create-lunaria.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import * as p from '@clack/prompts';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { addDependency, detectPackageManager, installDependencies } from 'nypm';
+import color from 'picocolors';
+
+const cleanConfigContent = (pkg: string) =>
+	`import { defineConfig } from "${pkg}";
+	
+export default defineConfig({});`;
+
+async function main() {
+	console.clear();
+
+	p.intro(`${color.bgGreen('create-lunaria')}`);
+
+	const project = await p.group(
+		{
+			package: () =>
+				p.select({
+					message: `Which ${color.bold('@lunariajs')} package would you like to set up?`,
+					initialValue: '@lunariajs/core',
+					options: [{ value: '@lunariajs/core', label: '@lunariajs/core' }],
+				}),
+			path: () =>
+				p.text({
+					message: 'Where should we set up Lunaria?',
+					placeholder: './rosetta-stone',
+					validate: (value) => {
+						if (value[0] !== '.') return 'Please enter a relative path.';
+					},
+				}),
+			typed: () =>
+				p.confirm({
+					message: 'Does your project use TypeScript?',
+					initialValue: false,
+				}),
+			install: ({ results }) =>
+				p.confirm({
+					message: `Do you wish to install ${color.bold(results.package)} and its dependencies?`,
+					initialValue: false,
+				}),
+		},
+		{
+			onCancel: () => {
+				p.cancel('Setup wizard cancelled.');
+				process.exit(0);
+			},
+		}
+	);
+
+	const projectPath = resolve(project.path);
+	const packageJsonPath = join(projectPath, 'package.json');
+
+	const packageManager = await detectPackageManager(projectPath, {
+		includeParentDirs: true,
+	});
+
+	if (!packageManager) {
+		p.cancel('Could not find your package manager. Setup wizard cancelled.');
+		process.exit(1);
+	}
+
+	const spinner = p.spinner();
+
+	spinner.start(`Adding ${color.bold(project.package)}`);
+
+	await addDependency(project.package, {
+		cwd: projectPath,
+		packageManager: packageManager,
+		silent: true,
+	});
+
+	spinner.stop(`Added ${color.bold(project.package)}.`);
+
+	if (existsSync(packageJsonPath)) {
+		spinner.start(`Adding ${color.bold('lunaria')} script`);
+		const file = readFileSync(packageJsonPath, 'utf-8');
+		const json = JSON.parse(file);
+
+		json.scripts = {
+			...json.scripts,
+			lunaria: 'lunaria',
+		};
+
+		writeFileSync(packageJsonPath, JSON.stringify(json, null, 2));
+
+		spinner.stop(`Added ${color.bold('lunaria')} script.`);
+	} else {
+		p.log.warn(
+			`Could not add the ${color.bold(
+				'lunaria'
+			)} script to your project. Refer to the Lunaria configuration to add it manually.`
+		);
+	}
+
+	if (project.install) {
+		spinner.start(`Installing via ${packageManager.name}`);
+
+		await installDependencies({
+			cwd: projectPath,
+			packageManager: packageManager,
+			silent: true,
+		});
+
+		spinner.stop(`Installed via ${packageManager.name}.`);
+	} else {
+		p.log.warn(
+			`Installation skipped. Don't forget to use ${color.bold(
+				`${packageManager.name} install`
+			)} before using Lunaria!`
+		);
+	}
+
+	const configFilename = `lunaria.config.${project.typed ? 'ts' : 'js'}`;
+	const configFilePath = join(projectPath, configFilename);
+
+	if (!existsSync(configFilePath)) {
+		writeFileSync(configFilePath, cleanConfigContent(project.package));
+		p.log.message(`${color.bold(configFilename)} created at ${color.italic(configFilePath)}`);
+	} else {
+		p.log.warn(
+			`Configuration skipped. ${color.bold(configFilename)} file already exists in your project.`
+		);
+	}
+
+	p.note(
+		`${project.path == '.' ? '' : `cd ${project.path}        \n`}${
+			project.install ? '' : `${packageManager.name} install\n`
+		}pnpm run lunaria`,
+		'Next steps: '
+	);
+
+	p.log.warn(`Do not forget to fill ${color.bold(configFilename)} before running Lunaria!`);
+
+	p.outro(
+		`Found any issues? ${color.underline(
+			color.cyan('https://github.com/Yan-Thomas/lunaria/issues/new')
+		)}`
+	);
+}
+
+main().catch(console.error);

--- a/packages/create-lunaria/tsconfig.json
+++ b/packages/create-lunaria/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "target": "ES2022",
+    "lib": ["es2022"],
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       prettier-plugin-organize-imports:
         specifier: ^3.2.3
         version: 3.2.3(prettier@3.0.3)(typescript@5.2.2)
+      unbuild:
+        specifier: ^2.0.0
+        version: 2.0.0(typescript@5.2.2)
 
   docs:
     dependencies:
@@ -91,9 +94,25 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
-      unbuild:
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.2.2)
+
+  packages/create-lunaria:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^0.7.0
+        version: 0.7.0
+      nypm:
+        specifier: ^0.3.3
+        version: 0.3.3
+      picocolors:
+        specifier: ^1.0.0
+        version: 1.0.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.8.9
+        version: 20.8.10
+      typescript:
+        specifier: ^5.2.2
+        version: 5.2.2
 
 packages:
 
@@ -492,6 +511,7 @@ packages:
   /@babel/highlight@7.22.20:
     resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
     engines: {node: '>=6.9.0'}
+    requiresBuild: true
     dependencies:
       '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
@@ -756,6 +776,23 @@ packages:
       human-id: 1.0.2
       prettier: 2.8.8
     dev: true
+
+  /@clack/core@0.3.3:
+    resolution: {integrity: sha512-5ZGyb75BUBjlll6eOa1m/IZBxwk91dooBWhPSL67sWcLS0zt9SnswRL0l26TVdBhb0wnWORRxUn//uH6n4z7+A==}
+    dependencies:
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+
+  /@clack/prompts@0.7.0:
+    resolution: {integrity: sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==}
+    dependencies:
+      '@clack/core': 0.3.3
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+    bundledDependencies:
+      - is-unicode-supported
 
   /@cspotcode/source-map-support@0.8.1:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1586,7 +1623,7 @@ packages:
   /@types/sax@1.2.5:
     resolution: {integrity: sha512-9jWta97bBVC027/MShr3gLab8gPhKy4l6qpb+UJLF5pDm3501NvA7uvqVCW+REFtx00oTi6Cq9JzLwgq6evVgw==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.8.10
     dev: false
 
   /@types/semver@7.5.4:
@@ -2260,7 +2297,6 @@ packages:
     resolution: {integrity: sha512-Q3bK1huLxzQrvj7hImJ7Z1vKYJRPQCDnd0EjXfHMidcjecGOMuLrmuQmtWmFkuKLcMThlGh1yCKG8IEc6VeNXQ==}
     dependencies:
       consola: 3.2.3
-    dev: true
 
   /cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
@@ -2357,7 +2393,6 @@ packages:
   /consola@3.2.3:
     resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
-    dev: true
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -4794,6 +4829,17 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
+    dev: false
+
+  /nypm@0.3.3:
+    resolution: {integrity: sha512-FHoxtTscAE723e80d2M9cJRb4YVjL82Ra+ZV+YqC6rfNZUWahi+ZhPF+krnR+bdMvibsfHCtgKXnZf5R6kmEPA==}
+    engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
+    dependencies:
+      citty: 0.1.4
+      execa: 8.0.1
+      pathe: 1.1.1
+      ufo: 1.3.1
     dev: false
 
   /object-inspect@1.13.1:


### PR DESCRIPTION
This PR adds the new `create-lunaria` package, meant to help users add Lunaria to their projects. It's a very basic version that will be expanded upon when we get to have other official Lunaria packages.