### PR TITLE
Rework `dashboard.site` option

### DIFF
--- a/examples/vitepress/lunaria.config.json
+++ b/examples/vitepress/lunaria.config.json
@@ -3,9 +3,6 @@
     "name": "Yan-Thomas/lunaria",
     "rootDir": "examples/vitepress"
   },
-  "dashboard": {
-    "url": "https://localhost:3000/"
-  },
   "defaultLocale": {
     "label": "English",
     "lang": "en",

--- a/packages/core/src/dashboard/components.ts
+++ b/packages/core/src/dashboard/components.ts
@@ -42,10 +42,10 @@ export const Meta = (dashboard: Dashboard) => html`
 	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 	<title>${dashboard.title}</title>
 	<meta name="description" content="${dashboard.description}" />
-	<link rel="canonical" href="${dashboard.url}" />
+	${dashboard.site ? html`<link rel="canonical" href="${dashboard.site}" />` : ''}
 	<meta property="og:title" content="${dashboard.title}" />
 	<meta property="og:type" content="website" />
-	<meta property="og:url" content="${dashboard.url}" />
+	${dashboard.site ? html`<meta property="og:url" content="${dashboard.site}" />` : ''}
 	<meta property="og:description" content="${dashboard.description}" />
 `;
 

--- a/packages/core/src/schemas/dashboard.ts
+++ b/packages/core/src/schemas/dashboard.ts
@@ -116,26 +116,33 @@ const DashboardUiSchema = z
 	})
 	.default({});
 
-export const DashboardSchema = z.object({
-	/** The title of your translation dashboard, used as both the main heading and meta title of the page. */
-	title: z
-		.string()
-		.default('Translation Status')
-		.describe(
-			'The title of your translation dashboard, used as both the main heading and meta title of the page.'
-		),
-	/** The description of your translation dashboard, used in the meta tags of the page. */
-	description: z
-		.string()
-		.default('Online translation status dashboard of the project ')
-		.describe('The description of your translation dashboard, used in the meta tags of the page.'),
-	/** The deployed URL of your translation dashboard, used in the meta tags of the page. */
-	url: z
-		.string()
-		.url()
-		.describe('The deployed URL of your translation dashboard, used in the meta tags of the page.'),
-	/** UI dictionary of the dashboard, including the desired `lang` and `dir` attributes of the page. */
-	ui: DashboardUiSchema,
-});
+export const DashboardSchema = z
+	.object({
+		/** The title of your translation dashboard, used as both the main heading and meta title of the page. */
+		title: z
+			.string()
+			.default('Translation Status')
+			.describe(
+				'The title of your translation dashboard, used as both the main heading and meta title of the page.'
+			),
+		/** The description of your translation dashboard, used in the meta tags of the page. */
+		description: z
+			.string()
+			.default('Online translation status dashboard of the project ')
+			.describe(
+				'The description of your translation dashboard, used in the meta tags of the page.'
+			),
+		/** The deployed URL of your translation dashboard, used in the meta tags of the page. */
+		site: z
+			.string()
+			.url()
+			.optional()
+			.describe(
+				'The deployed URL of your translation dashboard, used in the meta tags of the page.'
+			),
+		/** UI dictionary of the dashboard, including the desired `lang` and `dir` attributes of the page. */
+		ui: DashboardUiSchema,
+	})
+	.default({});
 
 export type Dashboard = z.output<typeof DashboardSchema>;


### PR DESCRIPTION
This PR changes the dashboard schema for `dashboard.url`, making it optional and renaming it to `dashboard.site`.