### PR TITLE
Add `dashboard.basesToHide` option

### DIFF
--- a/.changeset/good-dingos-wave.md
+++ b/.changeset/good-dingos-wave.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Add `dashboard.basesToHide` option

--- a/packages/core/src/dashboard/components.ts
+++ b/packages/core/src/dashboard/components.ts
@@ -127,8 +127,8 @@ export const LocaleDetails = (
 								(page) => html`
 									<li>
 										${page.gitHostingFileURL
-											? Link(page.gitHostingFileURL, page.sharedPath)
-											: page.sharedPath}
+											? Link(page.gitHostingFileURL, getCollapsedPath(dashboard, page.sharedPath))
+											: getCollapsedPath(dashboard, page.sharedPath)}
 										${page.translations[lang]?.gitHostingFileURL
 											? CreatePageLink(
 													page.translations[lang]?.gitHostingFileURL!,
@@ -223,7 +223,11 @@ export const TableBody = (
 				(page) =>
 					html`
 				<tr>
-					<td>${page.gitHostingFileURL ? Link(page.gitHostingFileURL, page.sharedPath) : page.sharedPath}</td>
+					<td>${
+						page.gitHostingFileURL
+							? Link(page.gitHostingFileURL, getCollapsedPath(dashboard, page.sharedPath))
+							: getCollapsedPath(dashboard, page.sharedPath)
+					}</td>
 						${locales.map(({ lang }) => {
 							return TableContentStatus(page.translations, lang, dashboard);
 						})}
@@ -256,7 +260,9 @@ export const ContentDetailsLinks = (
 	dashboard: Dashboard
 ) => {
 	return html`
-		${page.gitHostingFileURL ? Link(page.gitHostingFileURL, page.sharedPath) : page.sharedPath}
+		${page.gitHostingFileURL
+			? Link(page.gitHostingFileURL, getCollapsedPath(dashboard, page.sharedPath))
+			: getCollapsedPath(dashboard, page.sharedPath)}
 		${page.translations[lang]
 			? page.translations[lang]?.gitHostingFileURL || page.translations[lang]?.gitHostingHistoryURL
 				? html`(${page.translations[lang]?.gitHostingFileURL
@@ -334,3 +340,18 @@ export const ProgressBar = (
 		</span>
 	`;
 };
+
+function getCollapsedPath(dashboard: Dashboard, path: string) {
+	const { basesToHide } = dashboard;
+
+	if (!basesToHide) return path;
+
+	for (const base of basesToHide) {
+		const newPath = path.replace(base, '');
+
+		if (newPath === path) continue;
+		return newPath;
+	}
+
+	return path;
+}

--- a/packages/core/src/schemas/dashboard.ts
+++ b/packages/core/src/schemas/dashboard.ts
@@ -140,6 +140,11 @@ export const DashboardSchema = z
 			.describe(
 				'The deployed URL of your translation dashboard, used in the meta tags of the page.'
 			),
+		/** Array of path bases to hide from the rendered dashboard links. */
+		basesToHide: z
+			.array(z.string())
+			.optional()
+			.describe('Array of path bases to hide from the rendered dashboard links.'),
 		/** UI dictionary of the dashboard, including the desired `lang` and `dir` attributes of the page. */
 		ui: DashboardUiSchema,
 	})


### PR DESCRIPTION
This PR adds a new `dashboard.basesToHide` option, which receives an array of path bases that should be hidden from the rendered dashboard link labels. This is to make the dashboard more pleasing when your content is several levels deep from its content.