### PR TITLE
Add new `customCss` dashboard option

### DIFF
--- a/.changeset/brave-spoons-join.md
+++ b/.changeset/brave-spoons-join.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Add new `customCss` dashboard option

--- a/packages/core/config.schema.json
+++ b/packages/core/config.schema.json
@@ -1,0 +1,382 @@
+{
+  "$ref": "#/definitions/LunariaConfigSchema",
+  "definitions": {
+    "LunariaConfigSchema": {
+      "type": "object",
+      "properties": {
+        "dashboard": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "default": "Translation Status",
+              "description": "The title of your translation dashboard, used as both the main heading and meta title of the page."
+            },
+            "description": {
+              "type": "string",
+              "default": "Online translation status dashboard of the project ",
+              "description": "The description of your translation dashboard, used in the meta tags of the page."
+            },
+            "site": {
+              "type": "string",
+              "format": "uri",
+              "description": "The deployed URL of your translation dashboard, used in the meta tags of the page."
+            },
+            "basesToHide": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of path bases to hide from the rendered dashboard links."
+            },
+            "customCss": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of relative paths to CSS files to be inlined into the dashboard."
+            },
+            "ui": {
+              "type": "object",
+              "properties": {
+                "lang": {
+                  "type": "string",
+                  "default": "en",
+                  "description": "The BCP-47 tag of the dashboard's UI, used as the page's `lang` attribute, e.g. `'en'` or `'pt-BR'`."
+                },
+                "dir": {
+                  "type": "string",
+                  "enum": [
+                    "ltr",
+                    "rtl"
+                  ],
+                  "default": "ltr",
+                  "description": "The directionality of the page's text, used as the page's `dir` attribute. It can be either `'ltr'` (left-to-right) or `'rtl'` (right-to-left)."
+                },
+                "status.done": {
+                  "type": "string",
+                  "default": "done",
+                  "description": "The dashboard status of 'done'."
+                },
+                "status.outdated": {
+                  "type": "string",
+                  "default": "outdated",
+                  "description": "The dashboard status of 'outdated'."
+                },
+                "status.missing": {
+                  "type": "string",
+                  "default": "missing",
+                  "description": "The dashboard status 'missing'."
+                },
+                "status.emojiDone": {
+                  "type": "string",
+                  "default": "✔",
+                  "description": "The dashboard status emoji for 'done'."
+                },
+                "status.emojiOutdated": {
+                  "type": "string",
+                  "default": "🔄",
+                  "description": "The dashboard status emoji for 'outdated'."
+                },
+                "status.emojiMissing": {
+                  "type": "string",
+                  "default": "❌",
+                  "description": "The dashboard status emoji for 'missing'."
+                },
+                "statusByLocale.heading": {
+                  "type": "string",
+                  "default": "Translation progress by locale",
+                  "description": "The heading text that precedes the dropdown lists of each locale's individual progress."
+                },
+                "statusByLocale.detailsSummaryFormat": {
+                  "type": "string",
+                  "default": "{done_amount} {done_word}, {outdated_amount} {outdated_word}, {missing_amount} {missing_word}",
+                  "description": "The locale's individual status details summary format. The '{*_amount}' and `{*_word}` are placeholder values for the amount of pages (e.g. '10') in the status and the status word (e.g. 'done'), respectively."
+                },
+                "statusByLocale.detailsTitleFormat": {
+                  "type": "string",
+                  "default": "{locale_name} ({locale_tag})",
+                  "description": "The locale's details title format. The `{locale_name} and `{locale_tag}` are placeholder valuesfor the locale's name (e.g. English) and the locale's BCP-47 tag (e.g. en), respectively."
+                },
+                "statusByLocale.outdatedTranslationLink": {
+                  "type": "string",
+                  "default": "outdated translation",
+                  "description": "The text for the locale's details oudated translation link."
+                },
+                "statusByLocale.incompleteTranslationLink": {
+                  "type": "string",
+                  "default": "incomplete translation",
+                  "description": "The text for the locale's details incomplete translation link."
+                },
+                "statusByLocale.createFileLink": {
+                  "type": "string",
+                  "default": "Create page",
+                  "description": "The text for the locale's details create file link."
+                },
+                "statusByLocale.sourceChangeHistoryLink": {
+                  "type": "string",
+                  "default": "source change history",
+                  "description": "The text for the locale's details source change history link."
+                },
+                "statusByLocale.missingKeys": {
+                  "type": "string",
+                  "default": "Missing keys",
+                  "description": "The text for the locale's details UI dictionary missing keys heading."
+                },
+                "statusByLocale.completeTranslation": {
+                  "type": "string",
+                  "default": "This translation is complete, amazing job! 🎉",
+                  "description": "The text shown in the locale's details when it is complete."
+                },
+                "statusByContent.heading": {
+                  "type": "string",
+                  "default": "Translation status by content",
+                  "description": "The heading text that precedes the table with all locale's status by content."
+                },
+                "statusByContent.tableRowPage": {
+                  "type": "string",
+                  "default": "Content",
+                  "description": "The text for the status dashboard table's 'content' row head."
+                },
+                "statusByContent.tableSummaryFormat": {
+                  "type": "string",
+                  "default": "{missing_emoji} {missing_word} &nbsp; {outdated_emoji} {outdated_word} &nbsp; {done_emoji} {done_word}",
+                  "description": "The dashboard table's summary format. The `{*_emoji}` and `{*_word}` are placeholder values for the status emoji (e.g. '❌') and its word (e.g. 'missing')."
+                }
+              },
+              "additionalProperties": false,
+              "default": {}
+            }
+          },
+          "additionalProperties": false,
+          "default": {}
+        },
+        "repository": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The unique name of your repository in your git hosting platform, e.g. `\"Yan-Thomas/lunaria\"`."
+            },
+            "branch": {
+              "type": "string",
+              "default": "main",
+              "description": "The currently tracked branch of your repository."
+            },
+            "rootDir": {
+              "type": "string",
+              "default": "",
+              "description": "The root directory of the project being tracked, must be set when using a monorepo."
+            },
+            "hosting": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "github",
+                    "gitlab"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "create": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "source": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "history": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "clone": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "create",
+                    "source",
+                    "history",
+                    "clone"
+                  ],
+                  "additionalProperties": false
+                }
+              ],
+              "default": "github",
+              "description": "The git hosting platform used by your project, e.g. `\"github\"` or `\"gitlab\"`."
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        "defaultLocale": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "The label of the locale to show in the status dashboard, e.g. `\"English\"`, `\"Português\"`, or `\"Español\"`."
+            },
+            "lang": {
+              "type": "string",
+              "description": "The BCP-47 tag of the locale, both to use in smaller widths and to differentiate regional variants, e.g. `\"en-US\"` (American English) or `\"en-GB\"` (British English)."
+            },
+            "dictionaries": {
+              "type": "object",
+              "properties": {
+                "location": {
+                  "type": "string",
+                  "description": "A glob pattern of where your UI dictionaries are and its file type(s), e.g. `\"src/i18n/en/**.ts\"`."
+                },
+                "ignore": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [],
+                  "description": "Array of glob patterns to be ignored from matching."
+                },
+                "optionalKeys": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  },
+                  "default": {},
+                  "description": "Record of dictionary shared paths whose values are an array of dictionary keys to be marked as optional. While defining on the default locale's object applies it to all languages, you can pass additional keys as part of the specific locale's `optionalKeys` field."
+                }
+              },
+              "required": [
+                "location"
+              ],
+              "additionalProperties": false
+            },
+            "content": {
+              "type": "object",
+              "properties": {
+                "location": {
+                  "type": "string",
+                  "description": "A glob pattern of where your content for the locale is and its file type(s), e.g. `\"src/content/docs/en/**.mdx\"`."
+                },
+                "ignore": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [],
+                  "description": "Array of glob patterns to be ignored from matching."
+                }
+              },
+              "required": [
+                "location"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "label",
+            "lang",
+            "content"
+          ],
+          "additionalProperties": false
+        },
+        "locales": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LunariaConfigSchema/properties/defaultLocale"
+          },
+          "minItems": 1
+        },
+        "ignoreKeywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "en-only",
+            "i18nIgnore",
+            "fix typo"
+          ],
+          "description": "Array of commit keywords that avoid a commit from trigerring status changes."
+        },
+        "translatableProperty": {
+          "type": "string",
+          "description": "Name of the frontmatter property used to mark a page as ready for translation."
+        },
+        "routingStrategy": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "directory",
+                "file"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "regex": {
+                  "type": "string",
+                  "description": "The regex pattern to find the path section to be replaced. You can use :locales to dynamically add a list of all the locales in the format `'es|pt|ar'`."
+                },
+                "localePathReplaceWith": {
+                  "type": "string",
+                  "description": "The content that will be replaced into the `toLocalePath` regex's match. You can use :locale to dynamically add the current locale for you to replace with."
+                },
+                "sharedPathReplaceWith": {
+                  "type": "string",
+                  "description": "The content that will be replaced into the `toSharedPath` regex's match."
+                }
+              },
+              "required": [
+                "regex",
+                "localePathReplaceWith",
+                "sharedPathReplaceWith"
+              ],
+              "additionalProperties": false
+            }
+          ],
+          "default": "directory",
+          "description": "The routing strategy used by your framework, used to properly generate paths from a locale's path."
+        },
+        "outDir": {
+          "type": "string",
+          "default": "./dist/translation-status/index.html",
+          "description": "A relative directory path of where your dashboard will build to, e.g. `\"./dist/translation-status/index.html\"`."
+        },
+        "cloneDir": {
+          "type": "string",
+          "default": "./dist/history",
+          "description": "The relative directory path of your git history clone, exclusively made when running on a shallow repository, e.g. `\"./dist/history\"`"
+        },
+        "renderer": {
+          "type": "string",
+          "description": "The relative path to a valid `.(c/m)js` or `.(c/m)ts` file containing your dashboard renderer configuration."
+        },
+        "$schema": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository",
+        "defaultLocale",
+        "locales"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/packages/core/scripts/schema.ts
+++ b/packages/core/scripts/schema.ts
@@ -11,8 +11,8 @@ const mergedSchema = LunariaConfigSchema.merge(
 		.describe('A path or URL to a valid Lunaria JSON Schema.')
 );
 
-const jsonSchema = JSON.stringify(zodToJsonSchema(mergedSchema, 'LunariaConfigSchema'));
+const jsonSchema = JSON.stringify(zodToJsonSchema(mergedSchema, 'LunariaConfigSchema'), null, 2);
 
-writeFileSync('./dist/config.schema.json', jsonSchema);
+writeFileSync('./config.schema.json', jsonSchema);
 
 console.log('Lunaria JSON schema generated!');

--- a/packages/core/src/dashboard/components.ts
+++ b/packages/core/src/dashboard/components.ts
@@ -9,6 +9,7 @@ import type {
 } from '../types.js';
 import { getTextFromFormat } from '../utils/misc.js';
 import { Styles } from './styles.js';
+import { getCollapsedPath, inlineCustomCssFiles } from './utils.js';
 
 export const Page = (
 	opts: LunariaConfig,
@@ -17,6 +18,7 @@ export const Page = (
 ) => {
 	const { dashboard } = opts;
 	const { slots, overrides } = rendererOpts;
+	const inlinedCssFiles = inlineCustomCssFiles(dashboard.customCss);
 
 	return html`
 		<!doctype html>
@@ -26,8 +28,17 @@ export const Page = (
 				${overrides.meta?.(opts) ?? Meta(dashboard)}
 				<!-- Additional head tags -->
 				${slots.head?.(opts) ?? ''}
-				<!-- Built-in/custom styles -->
-				${overrides.styles?.(opts) ?? Styles}
+				<!-- Built-in styles -->
+				${Styles}
+				<!-- Custom styles -->
+				${inlinedCssFiles
+					? inlinedCssFiles.map(
+							(css) =>
+								html` <style>
+									${css}
+								</style>`
+					  )
+					: ''}
 			</head>
 			<body>
 				<!-- Built-in/custom body content -->
@@ -340,18 +351,3 @@ export const ProgressBar = (
 		</span>
 	`;
 };
-
-function getCollapsedPath(dashboard: Dashboard, path: string) {
-	const { basesToHide } = dashboard;
-
-	if (!basesToHide) return path;
-
-	for (const base of basesToHide) {
-		const newPath = path.replace(base, '');
-
-		if (newPath === path) continue;
-		return newPath;
-	}
-
-	return path;
-}

--- a/packages/core/src/dashboard/utils.ts
+++ b/packages/core/src/dashboard/utils.ts
@@ -1,0 +1,36 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { Dashboard } from '../types.js';
+
+export function getCollapsedPath(dashboard: Dashboard, path: string) {
+	const { basesToHide } = dashboard;
+
+	if (!basesToHide) return path;
+
+	for (const base of basesToHide) {
+		const newPath = path.replace(base, '');
+
+		if (newPath === path) continue;
+		return newPath;
+	}
+
+	return path;
+}
+
+export function inlineCustomCssFiles(customCssPaths: Dashboard['customCss']) {
+	if (!customCssPaths) return null;
+
+	const inlinedCss = customCssPaths.map((path) => {
+		const absolutePath = resolve(path);
+
+		if (!existsSync(absolutePath)) {
+			console.error(new Error(`Could not find the CSS file at ${absolutePath}. Does it exist?`));
+			process.exit(1);
+		}
+
+		const css = readFileSync(absolutePath, 'utf-8');
+		return css;
+	});
+
+	return inlinedCss;
+}

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -135,7 +135,6 @@ export const LunariaRendererConfigSchema = z.object({
 	overrides: z
 		.object({
 			meta: createComponentSchema<CustomComponent>().optional(),
-			styles: createComponentSchema<CustomComponent>().optional(),
 			body: createComponentSchema<CustomStatusComponent>().optional(),
 			statusByLocale: createComponentSchema<CustomStatusComponent>().optional(),
 			statusByContent: createComponentSchema<CustomStatusComponent>().optional(),

--- a/packages/core/src/schemas/dashboard.ts
+++ b/packages/core/src/schemas/dashboard.ts
@@ -1,3 +1,5 @@
+import { extname } from 'node:path';
+import { isRelative } from 'ufo';
 import { z } from 'zod';
 
 const DashboardUiSchema = z
@@ -145,6 +147,18 @@ export const DashboardSchema = z
 			.array(z.string())
 			.optional()
 			.describe('Array of path bases to hide from the rendered dashboard links.'),
+		/** Array of relative paths to CSS files to be inlined into the dashboard. */
+		customCss: z
+			.array(z.string())
+			.optional()
+			.refine(
+				(paths) =>
+					paths ? paths.every((path) => isRelative(path) && extname(path) === '.css') : true,
+				{
+					message: 'All `customCss` paths should be relative and point to a `.css` file.',
+				}
+			)
+			.describe('Array of relative paths to CSS files to be inlined into the dashboard.'),
 		/** UI dictionary of the dashboard, including the desired `lang` and `dir` attributes of the page. */
 		ui: DashboardUiSchema,
 	})


### PR DESCRIPTION
This PR adds a new `customCss` option to the dashboard, meaning you can add relative paths `.css` files that will be inlined and added to the final dashboard.