### PR TITLE
Change `ignoreKeywords` defaults

### DIFF
--- a/.changeset/fair-parrots-try.md
+++ b/.changeset/fair-parrots-try.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Change `ignoreKeywords` defaults

--- a/packages/core/config.schema.json
+++ b/packages/core/config.schema.json
@@ -46,7 +46,10 @@
                 },
                 "dir": {
                   "type": "string",
-                  "enum": ["ltr", "rtl"],
+                  "enum": [
+                    "ltr",
+                    "rtl"
+                  ],
                   "default": "ltr",
                   "description": "The directionality of the page's text, used as the page's `dir` attribute. It can be either `'ltr'` (left-to-right) or `'rtl'` (right-to-left)."
                 },
@@ -169,25 +172,42 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "enum": ["github", "gitlab"]
+                  "enum": [
+                    "github",
+                    "gitlab"
+                  ]
                 },
                 {
                   "type": "object",
                   "properties": {
                     "create": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "source": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "history": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "clone": {
                       "type": "string"
                     }
                   },
-                  "required": ["create", "source", "history", "clone"],
+                  "required": [
+                    "create",
+                    "source",
+                    "history",
+                    "clone"
+                  ],
                   "additionalProperties": false
                 }
               ],
@@ -195,7 +215,9 @@
               "description": "The git hosting platform used by your project, e.g. `\"github\"` or `\"gitlab\"`."
             }
           },
-          "required": ["name"],
+          "required": [
+            "name"
+          ],
           "additionalProperties": false
         },
         "defaultLocale": {
@@ -237,7 +259,9 @@
                   "description": "Record of dictionary shared paths whose values are an array of dictionary keys to be marked as optional. While defining on the default locale's object applies it to all languages, you can pass additional keys as part of the specific locale's `optionalKeys` field."
                 }
               },
-              "required": ["location"],
+              "required": [
+                "location"
+              ],
               "additionalProperties": false
             },
             "content": {
@@ -256,11 +280,17 @@
                   "description": "Array of glob patterns to be ignored from matching."
                 }
               },
-              "required": ["location"],
+              "required": [
+                "location"
+              ],
               "additionalProperties": false
             }
           },
-          "required": ["label", "lang", "content"],
+          "required": [
+            "label",
+            "lang",
+            "content"
+          ],
           "additionalProperties": false
         },
         "locales": {
@@ -275,7 +305,10 @@
           "items": {
             "type": "string"
           },
-          "default": ["en-only", "i18nIgnore", "fix typo"],
+          "default": [
+            "lunaria-ignore",
+            "fix typo"
+          ],
           "description": "Array of commit keywords that avoid a commit from trigerring status changes."
         },
         "translatableProperty": {
@@ -286,7 +319,10 @@
           "anyOf": [
             {
               "type": "string",
-              "enum": ["directory", "file"]
+              "enum": [
+                "directory",
+                "file"
+              ]
             },
             {
               "type": "object",
@@ -304,7 +340,11 @@
                   "description": "The content that will be replaced into the `toSharedPath` regex's match."
                 }
               },
-              "required": ["regex", "localePathReplaceWith", "sharedPathReplaceWith"],
+              "required": [
+                "regex",
+                "localePathReplaceWith",
+                "sharedPathReplaceWith"
+              ],
               "additionalProperties": false
             }
           ],
@@ -329,7 +369,11 @@
           "type": "string"
         }
       },
-      "required": ["repository", "defaultLocale", "locales"],
+      "required": [
+        "repository",
+        "defaultLocale",
+        "locales"
+      ],
       "additionalProperties": false
     }
   },

--- a/packages/core/src/schemas/config.ts
+++ b/packages/core/src/schemas/config.ts
@@ -82,7 +82,7 @@ export const LunariaConfigSchema = z.object({
 	/** Array of commit keywords that avoid a commit from trigerring status changes. */
 	ignoreKeywords: z
 		.array(z.string())
-		.default(['en-only', 'i18nIgnore', 'fix typo'])
+		.default(['lunaria-ignore', 'fix typo'])
 		.describe('Array of commit keywords that avoid a commit from trigerring status changes.'),
 	/** Name of the frontmatter property used to mark a page as translatable
 	 * and include it as part of the status dashboard. Keep it empty if you


### PR DESCRIPTION
This PR changes the `ignoreKeywords` defaults to `lunaria-ignore` and `fix typo` only.