### PR TITLE
Add support for tracking only dictionaries

### DIFF
--- a/.changeset/ten-lions-rush.md
+++ b/.changeset/ten-lions-rush.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Add support for tracking only dictionaries

--- a/packages/core/config.schema.json
+++ b/packages/core/config.schema.json
@@ -260,7 +260,7 @@
               "additionalProperties": false
             }
           },
-          "required": ["label", "lang", "content"],
+          "required": ["label", "lang"],
           "additionalProperties": false
         },
         "locales": {

--- a/packages/core/src/schemas/locale.ts
+++ b/packages/core/src/schemas/locale.ts
@@ -41,24 +41,28 @@ const ContentSchema = z.object({
 		.describe('Array of glob patterns to be ignored from matching.'),
 });
 
-export const LocaleSchema = z.object({
-	/** The label of the locale to show in the status dashboard, e.g. `"English"`, `"Português"`, or `"Español"`. */
-	label: z
-		.string()
-		.describe(
-			'The label of the locale to show in the status dashboard, e.g. `"English"`, `"Português"`, or `"Español"`.'
-		),
-	/** The BCP-47 tag of the locale, both to use in smaller widths and to differentiate regional variants, e.g. `"en-US"` (American English) or `"en-GB"` (British English). */
-	lang: z
-		.string()
-		.describe(
-			'The BCP-47 tag of the locale, both to use in smaller widths and to differentiate regional variants, e.g. `"en-US"` (American English) or `"en-GB"` (British English).'
-		),
-	/** Information about any of your UI dictionaries. */
-	dictionaries: DictionariesSchema,
-	/** Information about your content. */
-	content: ContentSchema,
-});
+export const LocaleSchema = z
+	.object({
+		/** The label of the locale to show in the status dashboard, e.g. `"English"`, `"Português"`, or `"Español"`. */
+		label: z
+			.string()
+			.describe(
+				'The label of the locale to show in the status dashboard, e.g. `"English"`, `"Português"`, or `"Español"`.'
+			),
+		/** The BCP-47 tag of the locale, both to use in smaller widths and to differentiate regional variants, e.g. `"en-US"` (American English) or `"en-GB"` (British English). */
+		lang: z
+			.string()
+			.describe(
+				'The BCP-47 tag of the locale, both to use in smaller widths and to differentiate regional variants, e.g. `"en-US"` (American English) or `"en-GB"` (British English).'
+			),
+		/** Information about any of your UI dictionaries. */
+		dictionaries: DictionariesSchema.optional(),
+		/** Information about your content. */
+		content: ContentSchema.optional(),
+	})
+	.refine((locale) => locale.content || locale.dictionaries, {
+		message: 'A locale needs to include a `dictionaries` or `content` field to be tracked.',
+	});
 
 export type Locale = z.output<typeof LocaleSchema>;
 export type OptionalKeys = z.infer<typeof OptionalKeysSchema>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,23 +2,23 @@ import type { TemplateResult } from 'lit-html';
 import type { LunariaConfig } from './schemas/config.js';
 import type { OptionalKeys } from './schemas/locale.js';
 
-type DictionaryContentData = {
+type DictionaryContentMeta = {
 	type: 'dictionary';
 	optionalKeys: OptionalKeys;
 };
 
-type GenericContentData = {
+type GenericContentMeta = {
 	type: 'generic';
 };
 
-type AdditionalContentData = DictionaryContentData | GenericContentData;
+type ContentMeta = DictionaryContentMeta | GenericContentMeta;
 
 export type * from './schemas/config.js';
 export type * from './schemas/dashboard.js';
 export type * from './schemas/locale.js';
 export type * from './schemas/misc.js';
 
-export type AugmentedFileData = FileData & AdditionalContentData;
+export type AugmentedFileData = FileData & ContentMeta;
 export type FileContentIndex = Record<string, Record<string, AugmentedFileData>>;
 
 export type IndexData = {
@@ -26,7 +26,7 @@ export type IndexData = {
 	filePath: string;
 	sharedPath: string;
 	fileData: FileData;
-	additionalData: AdditionalContentData;
+	meta: ContentMeta;
 };
 
 export type FileData = {


### PR DESCRIPTION
This PR adds support for tracking only dictionary-type files. Now, you can decide between choosing a `content` and/or `dictionaries` field depending on your type of project. This will also work for future tracking systems.