### PR TITLE
Add favicon support

### DIFF
--- a/.changeset/wild-turtles-admire.md
+++ b/.changeset/wild-turtles-admire.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Add favicon support

--- a/packages/core/config.schema.json
+++ b/packages/core/config.schema.json
@@ -36,6 +36,29 @@
               },
               "description": "Array of relative paths to CSS files to be inlined into the dashboard."
             },
+            "favicon": {
+              "type": "object",
+              "properties": {
+                "external": {
+                  "type": "object",
+                  "properties": {
+                    "link": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "sizes": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["link", "sizes"],
+                  "additionalProperties": false
+                },
+                "inline": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
             "ui": {
               "type": "object",
               "properties": {

--- a/packages/core/src/dashboard/components.ts
+++ b/packages/core/src/dashboard/components.ts
@@ -10,7 +10,7 @@ import type {
 } from '../types.js';
 import { getTextFromFormat } from '../utils/misc.js';
 import { Styles } from './styles.js';
-import { getCollapsedPath, inlineCustomCssFiles } from './utils.js';
+import { getCollapsedPath, inlineCustomCssFiles, readAsset } from './utils.js';
 
 export const Page = (
 	opts: LunariaConfig,
@@ -59,7 +59,23 @@ export const Meta = (dashboard: Dashboard): TemplateResult => html`
 	<meta property="og:type" content="website" />
 	${dashboard.site ? html`<meta property="og:url" content="${dashboard.site}" />` : nothing}
 	<meta property="og:description" content="${dashboard.description}" />
+	${Favicon(dashboard)}
 `;
+
+export const Favicon = (dashboard: Dashboard): TemplateResult => {
+	const { favicon } = dashboard;
+
+	const svg = favicon?.inline ? readAsset(favicon.inline) : '';
+	const inlineSvg = 'data:image/svg+xml;utf8,' + svg;
+
+	const ExternalFavicon = favicon?.external
+		? html`<link rel="icon" href="${favicon.external.link}" sizes="${favicon.external.sizes}" />`
+		: nothing;
+
+	const InlineFavicon = favicon?.inline ? html`<link rel="icon" href="${inlineSvg}" />` : nothing;
+
+	return html`${ExternalFavicon} ${InlineFavicon}`;
+};
 
 export const Body = (
 	opts: LunariaConfig,

--- a/packages/core/src/dashboard/utils.ts
+++ b/packages/core/src/dashboard/utils.ts
@@ -2,6 +2,18 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { Dashboard } from '../types.js';
 
+export function readAsset(path: string) {
+	const absolutePath = resolve(path);
+
+	if (!existsSync(absolutePath)) {
+		console.error(new Error(`Could not find asset file at ${absolutePath}. Does it exist?`));
+		process.exit(1);
+	}
+
+	const asset = readFileSync(absolutePath, 'utf-8');
+	return asset;
+}
+
 export function getCollapsedPath(dashboard: Dashboard, path: string) {
 	const { basesToHide } = dashboard;
 
@@ -21,14 +33,7 @@ export function inlineCustomCssFiles(customCssPaths: Dashboard['customCss']) {
 	if (!customCssPaths) return null;
 
 	const inlinedCss = customCssPaths.map((path) => {
-		const absolutePath = resolve(path);
-
-		if (!existsSync(absolutePath)) {
-			console.error(new Error(`Could not find the CSS file at ${absolutePath}. Does it exist?`));
-			process.exit(1);
-		}
-
-		const css = readFileSync(absolutePath, 'utf-8');
+		const css = readAsset(path);
 		return css;
 	});
 

--- a/packages/core/src/schemas/dashboard.ts
+++ b/packages/core/src/schemas/dashboard.ts
@@ -159,6 +159,27 @@ export const DashboardSchema = z
 				}
 			)
 			.describe('Array of relative paths to CSS files to be inlined into the dashboard.'),
+		favicon: z
+			.object({
+				external: z
+					.object({
+						link: z.string().url(),
+						sizes: z.string(),
+					})
+					.optional(),
+				inline: z
+					.string()
+					.refine((path) => isRelative(path) && extname(path) === '.svg', {
+						message:
+							'The `favicon.inline` path should be relative and point to a valid `.svg` file.',
+					})
+					.optional(),
+			})
+			.optional()
+			.refine((props) => !props || props?.external || props?.inline, {
+				message:
+					'The `favicon` object needs to receive either a valid `inline` or `external` property.',
+			}),
 		/** UI dictionary of the dashboard, including the desired `lang` and `dir` attributes of the page. */
 		ui: DashboardUiSchema,
 	})


### PR DESCRIPTION
This PR adds support for adding a favicon into your dashboard, be it through an `external` link or by inlining (`inline`) an SVG in the repository's file system. You can use both to have a fallback and preferred icon as well.