### PR TITLE
Display `packageManager.name` instead of hardcoding `pnpm`

### DIFF
--- a/.changeset/brown-pianos-flow.md
+++ b/.changeset/brown-pianos-flow.md
@@ -1,0 +1,5 @@
+---
+"create-lunaria": patch
+---
+
+Display `packageManager.name` instead of hardcoding `pnpm`

--- a/packages/create-lunaria/src/create-lunaria.ts
+++ b/packages/create-lunaria/src/create-lunaria.ts
@@ -121,7 +121,7 @@ async function main() {
 	p.note(
 		`${project.path == '.' ? '' : `cd ${project.path}        \n`}${
 			project.install ? '' : `${packageManager.name} install\n`
-		}pnpm run lunaria`,
+		}${packageManager.name} run lunaria`,
 		'Next steps: '
 	);
 


### PR DESCRIPTION
Within the "Next steps" of the setup wizard, `pnpm` is being displayed regardless of the type of package manager being used. Fixed to show `packageManager.name` instead.