### PR TITLE
Fix typo in manual-installation.mdx

### DIFF
--- a/docs/src/content/docs/manual-installation.mdx
+++ b/docs/src/content/docs/manual-installation.mdx
@@ -84,7 +84,7 @@ The following example sets up Lunaria to track Markdown/MDX content for both Eng
 			"label": "Português",
 			"lang": "pt",
 			"content": {
-				"location": "src/content/en/**/*.{md,mdx}"
+				"location": "src/content/pt/**/*.{md,mdx}"
 			}
 		}
 	]


### PR DESCRIPTION
Fixed the path in `content.location` for Portuguese locale.