### PR TITLE
Fix inline styles indentation

### DIFF
--- a/.changeset/silver-trees-poke.md
+++ b/.changeset/silver-trees-poke.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Fix inline styles indentation

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,7 @@
     "lit": "^3.1.0",
     "micromatch": "^4.0.5",
     "path-to-regexp": "^6.2.1",
+    "redent": "^4.0.0",
     "rehype": "^13.0.1",
     "rehype-format": "^5.0.0",
     "simple-git": "^3.20.0",

--- a/packages/core/src/dashboard/components.ts
+++ b/packages/core/src/dashboard/components.ts
@@ -1,5 +1,6 @@
 import { nothing, type TemplateResult } from 'lit';
 import { html, unsafeStatic } from 'lit/static-html.js';
+import redent from 'redent';
 import type {
 	Dashboard,
 	FileTranslationStatus,
@@ -35,9 +36,9 @@ export const Page = (
 				${inlinedCssFiles
 					? inlinedCssFiles.map(
 							(css) =>
-								html`<style>
-									${unsafeStatic(css)}
-								</style>`
+								html`${unsafeStatic(
+									redent(`<style>${redent('\n' + css, 1, { indent: '\t' })}</style>`, 4)
+								)}`
 					  )
 					: nothing}
 			</head>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       path-to-regexp:
         specifier: ^6.2.1
         version: 6.2.1
+      redent:
+        specifier: ^4.0.0
+        version: 4.0.0
       rehype:
         specifier: ^13.0.1
         version: 13.0.1
@@ -5064,6 +5067,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+    dev: false
+
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
@@ -6812,7 +6820,6 @@ packages:
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
-    dev: true
 
   /minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
@@ -7669,6 +7676,14 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
+  /redent@4.0.0:
+    resolution: {integrity: sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==}
+    engines: {node: '>=12'}
+    dependencies:
+      indent-string: 5.0.0
+      strip-indent: 4.0.0
+    dev: false
+
   /regenerator-runtime@0.14.0:
     resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
 
@@ -8490,6 +8505,13 @@ packages:
     dependencies:
       min-indent: 1.0.1
     dev: true
+
+  /strip-indent@4.0.0:
+    resolution: {integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==}
+    engines: {node: '>=12'}
+    dependencies:
+      min-indent: 1.0.1
+    dev: false
 
   /strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}


### PR DESCRIPTION

#### Description (required)

This PR fixes the indentation of inlined styles by using `redent` to remove redundant indentation and indent properly after.