### PR TITLE
Allow multiple `external` favicons

### DIFF
--- a/.changeset/ten-papayas-mix.md
+++ b/.changeset/ten-papayas-mix.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Allow multiple `external` favicons

--- a/packages/core/config.schema.json
+++ b/packages/core/config.schema.json
@@ -44,21 +44,25 @@
               "type": "object",
               "properties": {
                 "external": {
-                  "type": "object",
-                  "properties": {
-                    "link": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "The URL of the external favicon asset"
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "link": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The URL of the external favicon asset"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "The type attribute of the favicon, e.g. `\"image/x-icon\"` or `\"image/svg+xml\"`"
+                      }
                     },
-                    "sizes": {
-                      "type": "string",
-                      "description": "The size of the favicon, e.g. `\"16x16\"`"
-                    }
+                    "required": ["link", "type"],
+                    "additionalProperties": false
                   },
-                  "required": ["link", "sizes"],
-                  "additionalProperties": false,
-                  "description": "The external favicon to be used"
+                  "minItems": 1,
+                  "description": "Array of the external favicon(s) to be used"
                 },
                 "inline": {
                   "type": "string",

--- a/packages/core/src/dashboard/components.ts
+++ b/packages/core/src/dashboard/components.ts
@@ -70,7 +70,9 @@ export const Favicon = (dashboard: Dashboard): TemplateResult => {
 	const inlineSvg = 'data:image/svg+xml;utf8,' + svg;
 
 	const ExternalFavicon = favicon?.external
-		? html`<link rel="icon" href="${favicon.external.link}" sizes="${favicon.external.sizes}" />`
+		? html`${favicon.external.map(
+				(icon) => html`<link rel="icon" href="${icon.link}" type="${icon.type}" />`
+		  )}`
 		: nothing;
 
 	const InlineFavicon = favicon?.inline ? html`<link rel="icon" href="${inlineSvg}" />` : nothing;

--- a/packages/core/src/schemas/dashboard.ts
+++ b/packages/core/src/schemas/dashboard.ts
@@ -160,16 +160,23 @@ export const DashboardSchema = z
 		/** The favicon(s) to be used by your dashboard */
 		favicon: z
 			.object({
-				/* The external favicon to be used */
+				/* Array of the external favicon(s) to be used */
 				external: z
-					.object({
-						/* The URL of the external favicon asset */
-						link: z.string().url().describe('The URL of the external favicon asset'),
-						/* The size of the favicon, e.g. `"16x16"` */
-						sizes: z.string().describe('The size of the favicon, e.g. `"16x16"`'),
-					})
+					.array(
+						z.object({
+							/* The URL of the external favicon asset */
+							link: z.string().url().describe('The URL of the external favicon asset'),
+							/* The type attribute of the favicon, e.g. `"image/x-icon"`' */
+							type: z
+								.string()
+								.describe(
+									'The type attribute of the favicon, e.g. `"image/x-icon"` or `"image/svg+xml"`'
+								),
+						})
+					)
+					.nonempty()
 					.optional()
-					.describe('The external favicon to be used'),
+					.describe('Array of the external favicon(s) to be used'),
 				/* Path to an SVG to be inlined into the dashboard.  */
 				inline: z
 					.string()


### PR DESCRIPTION
#### Description (required)

This PR improves the `external` favicon API to allow for multiple external favicons.