### PR TITLE
Improve content API variables

### DIFF
--- a/.changeset/lucky-cycles-sparkle.md
+++ b/.changeset/lucky-cycles-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Improve content API variables

--- a/examples/nextra/lunaria.config.json
+++ b/examples/nextra/lunaria.config.json
@@ -7,7 +7,7 @@
   "files": [
     {
       "location": "pages/**/*.mdx",
-      "pattern": "pages/@path.@lang.mdx"
+      "pattern": "pages/:path+.@lang.mdx"
     }
   ],
   "defaultLocale": {

--- a/packages/core/src/tracker.ts
+++ b/packages/core/src/tracker.ts
@@ -285,10 +285,12 @@ export function getGitHostingLinks(repository: LunariaConfig['repository']) {
 export function getPathResolver(pattern: string, defaultLocale: Locale, locales: Locale[]) {
 	const langs = [defaultLocale, ...locales].map(({ lang }) => lang);
 
-	const langPattern = `:lang(${langs.join('|')})?`;
-	const langPatternDir = `{:lang(${langs.join('|')})/}?`;
-	const pathPattern = ':path+';
+	const localesPartial = langs.join('|');
+	const langPattern = `:lang(${localesPartial})?`;
+	const langPatternDir = `{:lang(${localesPartial})/}?`;
+	const pathPattern = ':path(.*)';
 	const augmentedPattern = getStringFromFormat(pattern, {
+		'@locales': localesPartial,
 		'@lang/': langPatternDir,
 		'@lang': langPattern,
 		'@path': pathPattern,


### PR DESCRIPTION
#### Description (required)

This PR improves the new content source API by changing the `@path` variable to a better pattern that better supports the conventional directory-based i18n. This does come with the need to use a custom `:path` for more specific strategies, e.g. Nextra's.

I've also added the `@locales` variables to give you an joined version of all the locales in case you also need to create a custom `:lang`.