### PR TITLE
Change `cloneDir` default

### DIFF
--- a/.changeset/dirty-pandas-know.md
+++ b/.changeset/dirty-pandas-know.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Change `cloneDir` default

--- a/packages/core/config.schema.json
+++ b/packages/core/config.schema.json
@@ -335,7 +335,7 @@
         },
         "cloneDir": {
           "type": "string",
-          "default": "./dist/lunaria/history",
+          "default": "./node_modules/.cache/lunaria/history",
           "description": "The relative directory path of your git history clone, exclusively made when running on a shallow repository, e.g. `\"./dist/lunaria/history\"`"
         },
         "renderer": {

--- a/packages/core/src/config/schemas.ts
+++ b/packages/core/src/config/schemas.ts
@@ -123,7 +123,7 @@ export const LunariaConfigSchema = z
 		/** The relative directory path of your git history clone, exclusively made when running on a shallow repository, e.g. `"./dist/lunaria/history"` */
 		cloneDir: z
 			.string()
-			.default('./dist/lunaria/history')
+			.default('./node_modules/.cache/lunaria/history')
 			.describe(
 				'The relative directory path of your git history clone, exclusively made when running on a shallow repository, e.g. `"./dist/lunaria/history"`'
 			),


### PR DESCRIPTION
#### Description (required)

This changes the `cloneDir` default to the `node_modules/.cache/lunaria/history`, which will avoid accidentally deploying the entire history by default.