### PR TITLE
Improve renderer components types

### DIFF
--- a/.changeset/fresh-peas-pay.md
+++ b/.changeset/fresh-peas-pay.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Improve renderer components types


### PR DESCRIPTION
#### Description (required)

This PR improves the renderer config's component types by adding the specified arguments using `z.custom()`. When using `z.function().args()` we get an exponential increase in bundle size, since the config schema will copied over each single time. This is unfortunate, but my main reason to introduce this was to add editor hints, instead of validating the arguments used.