### PR TITLE
Improve generated `gitHostingLinks.history()`

### DIFF
--- a/.changeset/yellow-worms-prove.md
+++ b/.changeset/yellow-worms-prove.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Improve generated `gitHostingLinks.history()`

--- a/packages/core/src/status/git.ts
+++ b/packages/core/src/status/git.ts
@@ -59,11 +59,10 @@ export function getGitHostingLinks(repository: LunariaConfig['repository']) {
 					`https://github.com/${name}/new/${branch}?filename=${cleanJoinURL(rootDir, filePath)}`,
 				source: (filePath: string) =>
 					`https://github.com/${name}/blob/${branch}/${cleanJoinURL(rootDir, filePath)}`,
-				history: (filePath: string, sinceDate: string) =>
-					`https://github.com/${name}/commits/${branch}/${cleanJoinURL(
-						rootDir,
-						filePath
-					)}?since=${sinceDate}`,
+				history: (filePath: string, sinceDate?: string) =>
+					`https://github.com/${name}/commits/${branch}/${cleanJoinURL(rootDir, filePath)}${
+						sinceDate ? `?since=${sinceDate}` : ''
+					}`,
 				clone: () => `https://github.com/${name}.git`,
 			};
 
@@ -73,11 +72,10 @@ export function getGitHostingLinks(repository: LunariaConfig['repository']) {
 					`https://gitlab.com/${name}/-/new/${branch}?file_name=${cleanJoinURL(rootDir, filePath)}`,
 				source: (filePath: string) =>
 					`https://gitlab.com/${name}/-/blob/${branch}/${cleanJoinURL(rootDir, filePath)}`,
-				history: (filePath: string, sinceDate: string) =>
-					`https://gitlab.com/${name}/-/commits/${branch}/${cleanJoinURL(
-						rootDir,
-						filePath
-					)}?since=${sinceDate}`,
+				history: (filePath: string, sinceDate?: string) =>
+					`https://gitlab.com/${name}/-/commits/${branch}/${cleanJoinURL(rootDir, filePath)}${
+						sinceDate ? `?since=${sinceDate}` : ''
+					}`,
 				clone: () => `https://gitlab.com/${name}.git`,
 			};
 	}

--- a/packages/core/src/status/index.ts
+++ b/packages/core/src/status/index.ts
@@ -143,7 +143,7 @@ async function getFileIndex(config: LunariaConfig, isShallowRepo: boolean) {
 
 				const gitHostingLinks = getGitHostingLinks(repository);
 				const gitHostingFileURL = gitHostingLinks.source(path);
-				const gitHostingHistoryURL = gitHostingLinks.history(path, '');
+				const gitHostingHistoryURL = gitHostingLinks.history(path);
 
 				const fileData = await getFileData(
 					path,


### PR DESCRIPTION
#### Description (required)

This PR improves the `gitHostingLinks.history()` by making `sinceDate` optional and not including the `since` query param if not passed.