### PR TITLE
Add `readConfig` and fix `writeConfig` issue

### DIFF
--- a/.changeset/brave-bats-wink.md
+++ b/.changeset/brave-bats-wink.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Add `readConfig` and fix `writeConfig` issue

--- a/packages/core/src/cli/sync/index.ts
+++ b/packages/core/src/cli/sync/index.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import {
-	loadConfig,
+	readConfig,
 	writeConfig,
 	type LunariaConfig,
 	type LunariaUserConfig,
@@ -102,7 +102,7 @@ export async function updateConfig(
 	file: LunariaUserConfig['files'][number],
 	skip: boolean
 ) {
-	const { rawUserConfig: config } = await loadConfig(configPath);
+	const config = await readConfig(configPath);
 
 	if (defaultLocale) {
 		let answer: boolean = true;
@@ -149,7 +149,8 @@ export async function updateConfig(
 			answer = Boolean(updateFiles);
 		}
 
-		const otherFiles = config.files?.filter((f) => f.location !== file.location) ?? [];
+		const otherFiles =
+			config.files?.filter((f: { location: string }) => f.location !== file.location) ?? [];
 
 		if (answer || skip) config.files = [file, ...otherFiles];
 	}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -19,15 +19,12 @@ const fromZodErrorOptions = {
 };
 
 export async function loadConfig(path: string) {
-	const resolvedPath = resolve(path);
-
-	if (/\.json$/.test(resolvedPath)) {
+	if (/\.json$/.test(path)) {
 		try {
-			const rawUserConfig = JSON.parse(readFileSync(resolvedPath, 'utf-8')) as LunariaUserConfig;
-			const userConfig = validateConfig(rawUserConfig);
+			const userConfig = validateConfig(readConfig(path));
 			const rendererConfig = await loadRendererConfig(userConfig.renderer);
 
-			return { rawUserConfig, userConfig, rendererConfig };
+			return { userConfig, rendererConfig };
 		} catch (e) {
 			console.error(error('Failed to load Lunaria config\n'));
 			throw e;
@@ -84,13 +81,31 @@ export function validateRendererConfig(config: LunariaUserRendererConfig) {
 	process.exit(1);
 }
 
+export function readConfig(path: string) {
+	const resolvedPath = resolve(path);
+
+	if (/\.json$/.test(resolvedPath)) {
+		try {
+			const configString = readFileSync(resolvedPath, 'utf-8');
+			return JSON.parse(configString);
+		} catch (e) {
+			console.error(error('Failed to write Lunaria config\n'));
+			throw e;
+		}
+	}
+
+	console.error(error('Invalid Lunaria config extension, expected .json'));
+	process.exit(1);
+}
+
 export function writeConfig(path: string, config: LunariaUserConfig) {
 	const resolvedPath = resolve(path);
 
 	if (/\.json$/.test(resolvedPath)) {
 		try {
-			const configJSON = JSON.stringify(config, null, 2);
-			writeFileSync(resolvedPath, configJSON);
+			const configString = JSON.stringify(config, null, 2);
+			writeFileSync(resolvedPath, configString);
+			return;
 		} catch (e) {
 			console.error(error('Failed to write Lunaria config\n'));
 			throw e;


### PR DESCRIPTION
#### Description (required)

This PR adds a new `readConfig` function to read the raw config when you want to read its JSON without any validation, generally to then write it back, like in the `sync` command or integrations such as `@lunariajs/starlight`. This also fixes an issue with `writeConfig` that would throw an invalid extension error, even when it's valid.