### PR TITLE
Remove `CHANGELOG.md` from the package install

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,8 +43,7 @@
   },
   "files": [
     "dist",
-    "config.schema.json",
-    "CHANGELOG.md"
+    "config.schema.json"
   ],
   "keywords": [
     "i18n",


### PR DESCRIPTION
#### Description (required)

This PR removes `CHANGELOG.md` from `@lunariajs/core`'s package installation files.