### PR TITLE
Add lunaria init command

### DIFF
--- a/.changeset/good-hats-drop.md
+++ b/.changeset/good-hats-drop.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Add lunaria init command

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -4,6 +4,7 @@ description: Learn how to get started with Lunaria
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 :::caution[Work in progress]
 Lunaria is currently in early access and **breaking changes** are bound to happen.
@@ -18,36 +19,111 @@ As a maintainer, managing localization efforts has never been easy, you'd always
 
 Every commit to select files is used to build a localization dashboard, giving each file its respective done/outdated/missing status. From the dashboard, maintainers get a detailed overview of their project's localization status while contributors receive all the information they need to efficiently help, including links to the missing files and a list of commits that need to be added to the outdated content.
 
-## Add to your project
+## Quick Start
 
-You can quickly add Lunaria to your project by running the following command in your terminal:
+### Add to your project
+
+You can add Lunaria in your existing project by installing `@lunariajs/core` in your project's dependencies using your preferred package manager:
 
 <Tabs>
 <TabItem label="npm">
 
 ```sh
-npm create lunaria@latest
+npm install @lunariajs/core
 ```
 
 </TabItem>
 <TabItem label="pnpm">
 
 ```sh
-pnpm create lunaria
+pnpm install @lunariajs/core
 ```
 
 </TabItem>
 <TabItem label="Yarn">
 
 ```sh
-yarn create lunaria
+yarn add @lunariajs/core
 ```
 
 </TabItem>
 </Tabs>
 
-This command will automatically create a new `lunaria.config.json` file, include an easy-to-use `lunaria` command to your `package.json`, and add all the necessary dependencies for your specific project.
+Then, you can run `lunaria init` to setup Lunaria, prompting you with a few questions and automatically filling your answers in a new `lunaria.config.json` file:
 
-:::note
-The `create-lunaria` setup wizard currently does not walk you through configuring the `lunaria.config.json` file. Visit the Reference section to manually proceed instead.
-:::
+<Tabs>
+<TabItem label="npm">
+
+```sh
+npx lunaria init
+```
+
+</TabItem>
+<TabItem label="pnpm">
+
+```sh
+pnpm lunaria init
+```
+
+</TabItem>
+<TabItem label="Yarn">
+
+```sh
+yarn lunaria init
+```
+
+</TabItem>
+</Tabs>
+
+Depending of your project's structure and if you run `lunaria sync` during the initialization successfully, you might have all the requirements to build your first localization dashboard.
+
+In case any of the fields `repository`, `defaultLocale`, `locales`, or `files` is missing in your `lunaria.config.json`, visit the [Configuration Reference guide](/reference/configuration) to set it up and then follow the instructions below.
+
+### Build your first dashboard
+
+To build your localization dashboard, you can run the `lunaria:build` script added by `lunaria init`:
+
+<Tabs>
+<TabItem label="npm">
+
+```sh
+npm run lunaria:build
+```
+
+</TabItem>
+<TabItem label="pnpm">
+
+```sh
+pnpm run lunaria:build
+```
+
+</TabItem>
+<TabItem label="Yarn">
+
+```sh
+yarn run lunaria:build
+```
+
+</TabItem>
+</Tabs>
+
+By default, the localization dashboard will be built to an `index.html` file in the `./dist/lunaria/` directory. This file can then be deployed to the hosting platform of your choice and shared across your contributors.
+
+### Next Steps
+
+Hooray! Your project's localization is now fully tracked by Lunaria! 🌛
+
+Lunaria comes with several features you can explore to make it suit your project best. Here are a few pages you can read next, in any order, to learn more about it:
+
+<CardGrid>
+	<LinkCard
+		title="Dashboard Customization"
+		description="Learn how to make your dashboard unique, with your own styles, structure, and more."
+		href="/guides/dashboard-customization/"
+	/>
+	<LinkCard
+		title="Tracking"
+		description="Learn how tracking works and how to track content in Lunaria."
+		href="/guides/tracking/"
+	/>
+</CardGrid>

--- a/docs/src/content/docs/manual-installation.mdx
+++ b/docs/src/content/docs/manual-installation.mdx
@@ -1,16 +1,19 @@
 ---
 title: Manual Installation
-description: Learn how to install Lunaria within your project
+description: Learn how to manually install Lunaria in your project
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
-import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-The most efficient way to add Lunaria to your project is using the `create-lunaria` package, as shown in the [Getting Started guide](/getting-started/). If you prefer to do this process manually, follow this guide instead.
+This guide will walk you through installing and configuring Lunaria in your existing project manually.
+
+:::tip
+Follow the [Getting Started guide's "Quick Start" section](/getting-started/#quick-start) for a simplified, CLI-guided set up.
+:::
 
 ## 1. Add the `@lunariajs/core` package
 
-Lunaria is published through the `@lunariajs/core` package in the npm registry. Add it to your project by running the following command in its root directory:
+Lunaria is published through the `@lunariajs/core` package in the npm registry. Add it to your project by running the following command in the project's root directory:
 
 <Tabs>
 <TabItem label="npm">
@@ -36,14 +39,14 @@ yarn add @lunariajs/core
 </TabItem>
 </Tabs>
 
-Then, add the `lunaria` executable script as part of your `package.json`'s `scripts` field:
+Then, add the following `lunaria` commands as part of your `package.json`'s `scripts` field:
 
 ```json title="package.json" ins={5}
 "scripts": {
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "lunaria": "lunaria"
+    "lunaria:build": "lunaria build",
 }
 ```
 
@@ -99,51 +102,8 @@ Learn more about all the available options in the [Configuration Reference guide
 Visit the [Lunaria repository's examples directory](https://github.com/Yan-Thomas/lunaria/tree/main/examples/) to see configuration examples for different frameworks and projects.
 :::
 
-## 4. Run Lunaria
+## 4. Next Steps
 
-Finally, you can generate your localization dashboard by running the `lunaria` script in the command line with your preferred package manager.
+Success, you're now ready to start using Lunaria in your project!
 
-<Tabs>
-<TabItem label="npm">
-
-```sh
-npm run lunaria
-```
-
-</TabItem>
-<TabItem label="pnpm">
-
-```sh
-pnpm run lunaria
-```
-
-</TabItem>
-<TabItem label="Yarn">
-
-```sh
-yarn run lunaria
-```
-
-</TabItem>
-</Tabs>
-
-By default, the localization dashboard will be built to an `index.html` file in the `./dist/lunaria/` directory. This file can then be deployed to the hosting platform of your choice and shared across your contributors.
-
-## Next Steps
-
-Hooray! Your project's localization is now fully tracked by Lunaria! 🌛
-
-Lunaria comes with several features you can explore to make it suit your project best. Here are a few pages you can read next, in any order, to learn more about it:
-
-<CardGrid>
-	<LinkCard
-		title="Dashboard Customization"
-		description="Learn how to make your dashboard unique, with your own styles, structure, and more."
-		href="/guides/dashboard-customization/"
-	/>
-	<LinkCard
-		title="Tracking"
-		description="Learn how tracking works and how to track content in Lunaria."
-		href="/guides/tracking/"
-	/>
-</CardGrid>
+If you followed this guide completely, you can jump to [Build your first dashboard](/getting-started#build-your-first-dashboard) to learn how to generate your localization dashboard and see our recommended next steps.

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -43,7 +43,8 @@ lunaria [command] [...options]
 Commands
 
     build  Build your dashboard and status to disk.
-     sync  Sync your config's files and/or locales fields based on your project's structure.
+     init  Initialize Lunaria in your project.
+     sync  Sync your config fields based on your project.
 
 Global Options
 
@@ -68,6 +69,10 @@ Builds your dashboard and status to disk. By default, the files will be output i
 The command will skip the status generation and use the latest already available status on disk instead.
 
 This option is recommended when you want to rebuild your dashboard constantly (e.g. to test styling changes) without waiting for the status to be built.
+
+### `lunaria init`
+
+Initializes Lunaria in your project, prompting you with a few questions and setting up a new `lunaria.config.json` for you.
 
 ### `lunaria sync`
 

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -16,9 +16,13 @@ const cli: CLI = {
 			],
 		},
 		{
+			name: 'init',
+			description: 'Initialize Lunaria in your project.',
+			usage: '[...options]',
+		},
+		{
 			name: 'sync',
-			description:
-				"Sync your config's files and/or locales fields based on your project's structure.",
+			description: 'Sync your config fields based on your project.',
 			usage: '[...options]',
 			options: [
 				{
@@ -63,6 +67,10 @@ async function main() {
 			case 'build':
 				const { build } = await import('./build/index.js');
 				await build(options);
+				break;
+			case 'init':
+				const { init } = await import('./init/index.js');
+				await init(options);
 				break;
 			case 'sync':
 				const { sync } = await import('./sync/index.js');

--- a/packages/core/src/cli/init/index.ts
+++ b/packages/core/src/cli/init/index.ts
@@ -1,0 +1,146 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+	bold,
+	confirm,
+	error,
+	failure,
+	highlight,
+	init as i,
+	isCancel,
+	select,
+	text,
+} from '../console.js';
+import type { InitOptions } from '../types.js';
+
+export async function init(options: InitOptions) {
+	const configPath = resolve(options.config ?? './lunaria.config.json');
+	const packageJsonPath = resolve('./package.json');
+
+	const config: Record<any, any> = {
+		$schema: './node_modules/@lunariajs/core/config.schema.json',
+		repository: {},
+	};
+
+	const gitHosting = await select({
+		message: i('What is the git hosting of your repository?'),
+		options: [
+			{
+				value: 'github',
+				label: 'GitHub',
+			},
+			{
+				value: 'gitlab',
+				label: 'GitLab',
+			},
+		],
+	});
+
+	if (isCancel(gitHosting)) {
+		console.log(failure('Operation cancelled.'));
+		process.exit(0);
+	}
+
+	// "github" is the default value, can be omitted.
+	if (gitHosting !== 'github') config.repository.hosting = gitHosting;
+
+	const repoName = await text({
+		message: i('What is the unique name of your repository?'),
+		placeholder: 'Yan-Thomas/lunaria',
+	});
+
+	if (isCancel(repoName)) {
+		console.log(failure('Operation cancelled.'));
+		process.exit(0);
+	}
+
+	config.repository.name = repoName;
+
+	const repoBranch = await text({
+		message: i('What is the main branch of your repository?'),
+		placeholder: 'main',
+	});
+
+	if (isCancel(repoBranch)) {
+		console.log(failure('Operation cancelled.'));
+		process.exit(0);
+	}
+
+	// "main" is the default value, can be omitted.
+	if (repoBranch !== 'main') config.repository.branch = repoBranch;
+
+	const isMonorepo = await confirm({
+		message: i("Are you setting Lunaria on a monorepo's project?"),
+		initialValue: false,
+	});
+
+	if (isCancel(isMonorepo)) {
+		console.log(failure('Operation cancelled.'));
+		process.exit(0);
+	}
+
+	if (isMonorepo) {
+		const repoRootDir = await text({
+			message: i('What is the root directory of your project?'),
+			placeholder: 'docs',
+		});
+
+		if (isCancel(repoRootDir)) {
+			console.log(failure('Operation cancelled.'));
+			process.exit(0);
+		}
+
+		config.repository.rootDir = repoRootDir;
+	}
+
+	try {
+		const configJson = JSON.stringify(config, null, 2);
+		writeFileSync(configPath, configJson);
+	} catch {
+		console.error(error('Failed to create your Lunaria config.'));
+	}
+
+	const trySync = await confirm({
+		message: i('Try syncing the rest of your config based on your project?'),
+		initialValue: false,
+	});
+
+	if (isCancel(trySync)) {
+		console.log(failure('Operation cancelled.'));
+		process.exit(0);
+	}
+
+	if (trySync) {
+		const { sync } = await import('../sync/index.js');
+		await sync({
+			config: options.config,
+			'skip-questions': false,
+			package: undefined,
+		});
+	}
+
+	if (existsSync(packageJsonPath)) {
+		try {
+			const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+			packageJson.scripts = {
+				...packageJson.scripts,
+				'lunaria:build': 'lunaria build',
+			};
+
+			writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+			console.log(i('Added lunaria scripts to your package.json file.'));
+		} catch {
+			console.error(error("Failed to update your package.json's scripts."));
+		}
+	}
+
+	console.log(i(`Config created at: ${highlight(configPath)}`));
+	console.log(
+		i(
+			`You're almost done, read your next steps: ${highlight(
+				'https://lunaria.dev/getting-started/#next-steps'
+			)}`
+		)
+	);
+	console.log(i(bold('Complete!')));
+}

--- a/packages/core/src/cli/sync/index.ts
+++ b/packages/core/src/cli/sync/index.ts
@@ -6,7 +6,16 @@ import {
 	type LunariaConfig,
 	type LunariaUserConfig,
 } from '../../config/index.js';
-import { bold, confirm, error, handleCancel, highlight, sync as s, select } from '../console.js';
+import {
+	bold,
+	confirm,
+	error,
+	failure,
+	highlight,
+	isCancel,
+	sync as s,
+	select,
+} from '../console.js';
 import { getFormattedTime } from '../helpers.js';
 import type { PackageJson, SyncOptions } from '../types.js';
 
@@ -67,9 +76,12 @@ async function getPackage() {
 			initialValue: options[0]?.value,
 		});
 
-		handleCancel(selected);
+		if (isCancel(selected)) {
+			console.log(failure('Operation cancelled.'));
+			process.exit(0);
+		}
 
-		return String(selected);
+		return selected;
 	}
 
 	return foundPackages[0];
@@ -112,9 +124,12 @@ export async function updateConfig(
 				initialValue: true,
 			});
 
-			handleCancel(updateDefaultLocale);
+			if (isCancel(updateDefaultLocale)) {
+				console.log(failure('Operation cancelled.'));
+				process.exit(0);
+			}
 
-			answer = Boolean(updateDefaultLocale);
+			answer = updateDefaultLocale;
 		}
 
 		if (answer || skip) config.defaultLocale = defaultLocale;
@@ -128,9 +143,12 @@ export async function updateConfig(
 				initialValue: true,
 			});
 
-			handleCancel(updateLocales);
+			if (isCancel(updateLocales)) {
+				console.log(failure('Operation cancelled.'));
+				process.exit(0);
+			}
 
-			answer = Boolean(updateLocales);
+			answer = updateLocales;
 		}
 
 		if (answer || skip) config.locales = locales;
@@ -144,9 +162,12 @@ export async function updateConfig(
 				initialValue: true,
 			});
 
-			handleCancel(updateFiles);
+			if (isCancel(updateFiles)) {
+				console.log(failure('Operation cancelled.'));
+				process.exit(0);
+			}
 
-			answer = Boolean(updateFiles);
+			answer = updateFiles;
 		}
 
 		const otherFiles =

--- a/packages/core/src/cli/types.ts
+++ b/packages/core/src/cli/types.ts
@@ -20,6 +20,8 @@ export type SyncOptions = GlobalOptions & {
 	'skip-questions': boolean | undefined;
 };
 
+export type InitOptions = GlobalOptions;
+
 export type PackageJson = {
 	dependencies?: Record<string, string>;
 	devDependencies?: Record<string, string>;


### PR DESCRIPTION
#### Description (required)

This PR adds the new `lunaria init` command, meant to be used instead of `create-lunaria`, which will be deprecated soon. The documentation has also been updated to reflect this.