### PR TITLE
Miscellaneous fixes and optimizations

### DIFF
--- a/build.preset.ts
+++ b/build.preset.ts
@@ -6,7 +6,6 @@ export default definePreset({
 	rollup: {
 		esbuild: {
 			target: 'es2022',
-			minify: true,
 		},
 	},
 });

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -80,7 +80,7 @@ Syncs your configuration file's `files`, `defaultLocale`, and/or `locales` field
 
 This command works by analyzing your project's `package.json` for packages Lunaria can infer the configuration, generally from its own configuration file or default content structure.
 
-The currently supported packages in `lunaria sync` are: `vitepress`.
+The currently supported packages in `lunaria sync` are `vitepress` and `@astrojs/starlight`.
 
 #### Options
 

--- a/packages/core/src/cli/init/index.ts
+++ b/packages/core/src/cli/init/index.ts
@@ -47,6 +47,9 @@ export async function init(options: InitOptions) {
 	const repoName = await text({
 		message: i('What is the unique name of your repository?'),
 		placeholder: 'Yan-Thomas/lunaria',
+		validate(value) {
+			if (value.trim().length < 1) return 'The repository name cannot be empty.';
+		},
 	});
 
 	if (isCancel(repoName)) {
@@ -59,6 +62,9 @@ export async function init(options: InitOptions) {
 	const repoBranch = await text({
 		message: i('What is the main branch of your repository?'),
 		placeholder: 'main',
+		validate(value) {
+			if (value.trim().length < 1) return 'The branch name cannot be empty.';
+		},
 	});
 
 	if (isCancel(repoBranch)) {
@@ -83,6 +89,13 @@ export async function init(options: InitOptions) {
 		const repoRootDir = await text({
 			message: i('What is the root directory of your project?'),
 			placeholder: 'docs',
+			validate(value) {
+				if (value.trim().length < 1) return 'The root directory cannot be empty.';
+				if (value.trim().startsWith('./') || value.trim().startsWith('../'))
+					return 'The root directory cannot be a relative path.';
+				if (value.trim().endsWith('/'))
+					return 'The root directory cannot end with a trailing slash.';
+			},
 		});
 
 		if (isCancel(repoRootDir)) {

--- a/packages/core/src/cli/sync/index.ts
+++ b/packages/core/src/cli/sync/index.ts
@@ -16,15 +16,12 @@ import {
 	sync as s,
 	select,
 } from '../console.js';
-import { getFormattedTime } from '../helpers.js';
 import type { PackageJson, SyncOptions } from '../types.js';
 
 /** Packages that we support sync with. */
-const supportedPackages = ['vitepress'];
+const supportedPackages = ['vitepress', '@astrojs/starlight'];
 
 export async function sync(options: SyncOptions) {
-	const syncStartTime = performance.now();
-
 	if (!options.package) console.log(s('Looking for syncable packages...'));
 
 	const configPath = options.config ?? './lunaria.config.json';
@@ -42,14 +39,17 @@ export async function sync(options: SyncOptions) {
 			const { vitepress } = await import('./vitepress.js');
 			await vitepress(configPath, skipQuestions);
 			break;
+		case '@astrojs/starlight':
+			console.log(s(`Syncing with ${highlight('Starlight')}...`));
+			const { starlight } = await import('./starlight.js');
+			await starlight(configPath, skipQuestions);
+			break;
 		default:
 			console.error(error(`The selected package ${selectedPackage} is not supported`));
 			break;
 	}
 
-	const syncEndTime = performance.now();
-
-	console.log(s(`${bold('Complete!')} Synced in ${getFormattedTime(syncStartTime, syncEndTime)}`));
+	console.log(s(bold('Complete!')));
 }
 
 async function getPackage() {
@@ -93,7 +93,7 @@ function loadPackageJson() {
 	try {
 		const packageJson: PackageJson = JSON.parse(readFileSync(resolvedPath, 'utf-8'));
 
-		if (!packageJson.dependencies || !packageJson.devDependencies) {
+		if (!packageJson.dependencies && !packageJson.devDependencies) {
 			console.error(
 				error('Failed to find a dependencies or devDependencies field in your package.json\n')
 			);

--- a/packages/core/src/cli/sync/starlight.ts
+++ b/packages/core/src/cli/sync/starlight.ts
@@ -1,0 +1,12 @@
+import type { LunariaUserConfig } from '../../config/index.js';
+import { updateConfig } from './index.js';
+
+export async function starlight(configPath: string, skipQuestions: boolean) {
+	const file: LunariaUserConfig['files'][number] = {
+		location: 'src/content/docs/**/*.{md,mdx}',
+		pattern: 'src/content/docs/@lang/@path',
+		type: 'universal',
+	};
+
+	await updateConfig(configPath, undefined, undefined, file, skipQuestions);
+}


### PR DESCRIPTION
#### Description (required)

This PR makes miscellaneous fixes and optimizations to `@lunariajs/core`:
- Fixed an issue where `sync` would error if you only had `dependencies` or `devDependencies` in your `package.json`
- Added `@astrojs/starlight` to sync's supported packages.
- Added proper validation to `lunaria init` text prompts.
- Optimized the way `localizableProperty` works by automatically skipping frontmatter parsing in non-source locales.
- Unminified build output to simplify debugging and patching.