### PR TITLE
Add lunaria preview command

### DIFF
--- a/.changeset/honest-ligers-dress.md
+++ b/.changeset/honest-ligers-dress.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Add lunaria preview command

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -109,6 +109,34 @@ yarn run lunaria:build
 
 By default, the localization dashboard will be built to an `index.html` file in the `./dist/lunaria/` directory. This file can then be deployed to the hosting platform of your choice and shared across your contributors.
 
+### See it in your browser
+
+After building your dashboard, you should be able to run `lunaria:preview` to open a new preview server on [http://localhost:3000/](http://localhost:3000/).
+
+<Tabs>
+<TabItem label="npm">
+
+```sh
+npm run lunaria:preview
+```
+
+</TabItem>
+<TabItem label="pnpm">
+
+```sh
+pnpm run lunaria:preview
+```
+
+</TabItem>
+<TabItem label="Yarn">
+
+```sh
+yarn run lunaria:preview
+```
+
+</TabItem>
+</Tabs>
+
 ### Next Steps
 
 Hooray! Your project's localization is now fully tracked by Lunaria! 🌛

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -27,8 +27,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		is built to make your experience as seamless as possible.
 	</Card>
 	<Card title="Really, really fast" icon="rocket">
-		Fast enough to build a dashboard tracking +1000 pages on over 12 locales in
-		just 30 seconds.
+		Fast enough to build a dashboard tracking thousands of files on over a dozen
+		locales in less than a minute.
 	</Card>
 	<Card title="Integrated with GitHub" icon="github">
 		Get an overview and helpful insights on how PRs are going to affect your

--- a/docs/src/content/docs/manual-installation.mdx
+++ b/docs/src/content/docs/manual-installation.mdx
@@ -47,6 +47,7 @@ Then, add the following `lunaria` commands as part of your `package.json`'s `scr
     "build": "astro build",
     "preview": "astro preview",
     "lunaria:build": "lunaria build",
+	"lunaria:preview": "lunaria preview",
 }
 ```
 
@@ -106,4 +107,4 @@ Visit the [Lunaria repository's examples directory](https://github.com/Yan-Thoma
 
 Success, you're now ready to start using Lunaria in your project!
 
-If you followed this guide completely, you can jump to [Build your first dashboard](/getting-started#build-your-first-dashboard) to learn how to generate your localization dashboard and see our recommended next steps.
+If you followed this guide completely, you can jump to [Build your first dashboard](/getting-started#build-your-first-dashboard) to learn how to generate your localization dashboard, see it in your browser, and our recommended next steps.

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -85,7 +85,7 @@ This command is not meant for being used in production. For production hosting, 
 
 ##### `--port <number>`
 
-Specifies which port to open the preview server on. By default, `3000` will be used if available, if `3000` or your specified port isn't available, a random available port will be used instead.
+Specifies which port to open the preview server on. By default, `3000` will be used. If `3000` or your specified port isn't available, a random available port will be used instead.
 
 ### `lunaria sync`
 

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -44,6 +44,7 @@ Commands
 
     build  Build your dashboard and status to disk.
      init  Initialize Lunaria in your project.
+  preview  Preview your built dashboard locally.
      sync  Sync your config fields based on your project.
 
 Global Options
@@ -72,7 +73,19 @@ This option is recommended when you want to rebuild your dashboard constantly (e
 
 ### `lunaria init`
 
-Initializes Lunaria in your project, prompting you with a few questions and setting up a new `lunaria.config.json` for you.
+Initializes Lunaria in your project, prompting you with a few questions and setting up a new `lunaria.config.json` file.
+
+### `lunaria preview`
+
+Starts a local server to serve your latest localization dashboard built by [`lunaria build`](#lunaria-build).
+
+This command is not meant for being used in production. For production hosting, see our specific deploy instructions.
+
+#### Options
+
+##### `--port <number>`
+
+Specifies which port to open the preview server on. By default, `3000` will be used if available, if `3000` or your specified port isn't available, a random available port will be used instead.
 
 ### `lunaria sync`
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,6 +75,7 @@
   "dependencies": {
     "@clack/core": "^0.3.3",
     "fast-glob": "^3.3.1",
+    "get-port": "^7.0.0",
     "jiti": "^1.21.0",
     "micromatch": "^4.0.5",
     "path-to-regexp": "^6.2.1",

--- a/packages/core/src/cli/console.ts
+++ b/packages/core/src/cli/console.ts
@@ -173,3 +173,9 @@ export function init(message: string) {
 
 	return `${badge} ${message}`;
 }
+
+export function preview(message: string) {
+	const badge = pc.yellow('[preview]');
+
+	return `${badge} ${message}`;
+}

--- a/packages/core/src/cli/helpers.ts
+++ b/packages/core/src/cli/helpers.ts
@@ -21,6 +21,10 @@ export function parseCommand() {
 			'skip-questions': {
 				type: 'boolean',
 			},
+			/** Preview command */
+			port: {
+				type: 'string',
+			},
 		},
 	});
 

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -21,6 +21,17 @@ const cli: CLI = {
 			usage: '[...options]',
 		},
 		{
+			name: 'preview',
+			description: 'Preview your built dashboard locally.',
+			usage: '[...options]',
+			options: [
+				{
+					name: '--port <number>',
+					description: 'Specify which port to open the preview server on.',
+				},
+			],
+		},
+		{
 			name: 'sync',
 			description: 'Sync your config fields based on your project.',
 			usage: '[...options]',
@@ -71,6 +82,10 @@ async function main() {
 			case 'init':
 				const { init } = await import('./init/index.js');
 				await init(options);
+				break;
+			case 'preview':
+				const { preview } = await import('./preview/index.js');
+				await preview(options);
 				break;
 			case 'sync':
 				const { sync } = await import('./sync/index.js');

--- a/packages/core/src/cli/init/index.ts
+++ b/packages/core/src/cli/init/index.ts
@@ -138,6 +138,7 @@ export async function init(options: InitOptions) {
 			packageJson.scripts = {
 				...packageJson.scripts,
 				'lunaria:build': 'lunaria build',
+				'lunaria:preview': 'lunaria preview',
 			};
 
 			writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));

--- a/packages/core/src/cli/preview/index.ts
+++ b/packages/core/src/cli/preview/index.ts
@@ -1,0 +1,35 @@
+import getPort from 'get-port';
+import { existsSync, readFileSync } from 'node:fs';
+import http from 'node:http';
+import { join, resolve } from 'node:path';
+import { loadConfig } from '../../config/index.js';
+import { bold, highlight, preview as p } from '../console.js';
+import type { PreviewOptions } from '../types.js';
+
+export async function preview(options: PreviewOptions) {
+	const configPath = options.config ?? './lunaria.config.json';
+	const serverPort = await getPort({ port: options.port ? parseInt(options.port) : 3000 });
+
+	const { userConfig } = await loadConfig(configPath);
+
+	const outDir = resolve(userConfig.outDir);
+	const dashboardPath = join(outDir, 'index.html');
+
+	if (!existsSync(dashboardPath)) {
+		console.log(p(`Could not find a build to preview at ${highlight(dashboardPath)}`));
+		process.exit(0);
+	}
+
+	http
+		.createServer((_, res) => {
+			const dashboardFile = readFileSync(dashboardPath);
+
+			res.writeHead(200, { 'Content-Type': 'text/html' });
+			res.write(dashboardFile, 'binary');
+			res.end();
+		})
+		.listen(serverPort);
+
+	console.log(p(`Server open on ${highlight(`http://localhost:${serverPort.toString()}/`)}`));
+	console.log(p(`Press ${bold('CNTRL + C')} to close it.`));
+}

--- a/packages/core/src/cli/types.ts
+++ b/packages/core/src/cli/types.ts
@@ -22,6 +22,10 @@ export type SyncOptions = GlobalOptions & {
 
 export type InitOptions = GlobalOptions;
 
+export type PreviewOptions = GlobalOptions & {
+	port: string | undefined;
+};
+
 export type PackageJson = {
 	dependencies?: Record<string, string>;
 	devDependencies?: Record<string, string>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       fast-glob:
         specifier: ^3.3.1
         version: 3.3.2
+      get-port:
+        specifier: ^7.0.0
+        version: 7.0.0
       jiti:
         specifier: ^1.21.0
         version: 1.21.0
@@ -4231,6 +4234,11 @@ packages:
       has-symbols: 1.0.3
       hasown: 2.0.0
     dev: true
+
+  /get-port@7.0.0:
+    resolution: {integrity: sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==}
+    engines: {node: '>=16'}
+    dev: false
 
   /get-stream@3.0.0:
     resolution: {integrity: sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==}


### PR DESCRIPTION
#### Description (required)

This PR adds the new `lunaria preview` command, meant to start a preview server with your built dashboard from `lunaria build`.

This also adds a new `lunaria:preview` added by `lunaria init`, while updates the documentation to mention it.
