### PR TITLE
Fix jiti type and bundling issue

### DIFF
--- a/.changeset/famous-bikes-carry.md
+++ b/.changeset/famous-bikes-carry.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/core": patch
+---
+
+Fix jiti type and bundling issue

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,4 +1,4 @@
-import jiti from 'jiti';
+import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import { error, highlight } from './cli/console.js';
 
@@ -19,9 +19,10 @@ export function getStringFromFormat(
 	return formatResult;
 }
 
-/** TODO: Use `jiti.import` instead when available. */
 export function loadWithJiti(path: string) {
-	// @ts-expect-error
+	const require = createRequire(import.meta.url);
+	const jiti = require('jiti');
+
 	const loadFile = jiti(process.cwd(), {
 		interopDefault: true,
 		esmResolve: true,


### PR DESCRIPTION
#### Description (required)

Fixes an type and bundling issue with `jiti` by importing it through a require, instead of a normal ESM import.
