### PR TITLE
Remove CLI redirect

### DIFF
--- a/.changeset/twenty-pants-draw.md
+++ b/.changeset/twenty-pants-draw.md
@@ -1,0 +1,5 @@
+---
+"@lunariajs/starlight": patch
+---
+
+Remove CLI redirect

--- a/examples/starlight/package.json
+++ b/examples/starlight/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@astrojs/check": "^0.4.1",
     "@astrojs/starlight": "^0.16.0",
+    "@lunariajs/core": "workspace:^",
     "@lunariajs/starlight": "workspace:^",
     "astro": "^4.2.1",
     "sharp": "^0.32.5",

--- a/packages/starlight/README.md
+++ b/packages/starlight/README.md
@@ -19,6 +19,19 @@ pnpm add @lunariajs/starlight
 yarn add @lunariajs/starlight
 ```
 
+To use `@lunariajs/starlight` properly you also need to install Lunaria's core package:
+
+```bash
+# npm
+npm install @lunariajs/core
+
+# pnpm
+pnpm add @lunariajs/core
+
+# yarn
+yarn add @lunariajs/core
+```
+
 ## Basic Usage
 
 Start using `@lunariajs/starlight` by setting up your own `lunaria.config.json` file and adding the provided integration to your `astro.config.*` file.

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -3,9 +3,6 @@
   "type": "module",
   "version": "0.0.2",
   "description": "Lunaria integration for the Starlight documentation theme for Astro",
-  "bin": {
-    "lunaria": "./src/bin/lunaria.mjs"
-  },
   "exports": {
     ".": "./src/index.ts",
     "./Dashboard.astro": "./src/components/Dashboard.astro",
@@ -34,9 +31,7 @@
   "bugs": "https://github.com/Yan-Thomas/lunaria/issues",
   "peerDependencies": {
     "@astrojs/starlight": ">=0.14.0",
-    "astro": ">=4.0.0"
-  },
-  "dependencies": {
+    "astro": ">=4.0.0",
     "@lunariajs/core": "workspace:^"
   }
 }

--- a/packages/starlight/src/bin/lunaria.mjs
+++ b/packages/starlight/src/bin/lunaria.mjs
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-import('@lunariajs/core/cli');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.16.0
         version: 0.16.0(astro@4.2.1)
+      '@lunariajs/core':
+        specifier: workspace:^
+        version: link:../../packages/core
       '@lunariajs/starlight':
         specifier: workspace:^
         version: link:../../packages/starlight


### PR DESCRIPTION
#### Description (required)

Removes the CLI redirect from `@lunariajs/core` in `@lunariajs/starlight`. The recommendation is to have both installed as dependencies in your project, not as a subdependency. 